### PR TITLE
docs: Add missing user stories for v1.4 and v1.5

### DIFF
--- a/plans/IMP-013-User-Notifications.md
+++ b/plans/IMP-013-User-Notifications.md
@@ -1,0 +1,36 @@
+# Implementation Plan - US-013: User Notifications
+
+## Goal
+Notify decision owners via email when new arguments are added to their decisions.
+
+## Proposed Changes
+
+### Backend (Cloud Functions)
+#### [NEW] `functions/src/notifications.ts` (or similar)
+-   Create a Firestore trigger: `exports.notifyOnNewArgument = functions.firestore.document('decisions/{decisionId}/arguments/{argumentId}').onCreate(...)`
+-   Logic:
+    1.  Fetch parent decision (`decisions/{decisionId}`).
+    2.  Check if decision has an `ownerId`.
+    3.  Fetch owner's email (via Admin SDK `admin.auth().getUser(ownerId)`).
+    4.  Send email (using a helper function/service).
+
+#### [MODIFY] `functions/package.json`
+-   Add `nodemailer` (or configure Firebase Email Extension). *Decision: Use Nodemailer for custom control if no extension pre-installed, or assume standard SMTP.*
+
+### Frontend (React)
+#### [MODIFY] `src/pages/Dashboard.tsx` (or Profile)
+-   Add a toggle: "Receive email notifications" (requires storing user preferences in a `users` collection).
+-   *Note*: For MVP of this story, we might skip the UI toggle and default to "On", but the story AC mentions Opt-out.
+-   *Refinement*: Create `users` collection to store preferences if not exists.
+
+## Verification Plan
+
+### Automated Tests
+-   **Unit Tests (Functions)**: Mock Firestore trigger and verify email sending logic is called.
+
+### Manual Verification
+1.  Login as User A.
+2.  Create a decision.
+3.  Login as User B (or Incognito).
+4.  Add an argument to User A's decision.
+5.  Verify User A receives an email.

--- a/plans/IMP-014-Restrict-Closing.md
+++ b/plans/IMP-014-Restrict-Closing.md
@@ -1,0 +1,36 @@
+# Implementation Plan - US-014: Restrict Decision Closing
+
+## Goal
+Enforce ownership for closing decisions.
+
+## Proposed Changes
+
+### Firestore Rules
+#### [MODIFY] `firestore.rules`
+-   Update the `update` rule for `decisions/{decisionId}`.
+-   Condition:
+    ```
+    allow update: if request.resource.data.diff(resource.data).affectedKeys().hasOnly(['status']) 
+                  && (resource.data.ownerId == null || request.auth.uid == resource.data.ownerId);
+    ```
+    *(Refine logic to ensure other fields aren't compromised, but focus on status).*
+
+### Frontend (React)
+#### [MODIFY] `src/pages/Decision.tsx`
+-   Check `user` object from AuthContext.
+-   If `decision.ownerId` exists and `user.uid !== decision.ownerId`, hide the "Close Decision" button.
+-   Show a tooltip or message if needed? (Probably just hide it).
+
+## Verification Plan
+
+### Automated Tests
+-   **Firestore Emulator**:
+    -   Test: Non-owner tries to update status -> Deny.
+    -   Test: Owner tries to update status -> Allow.
+    -   Test: Anonymous user updates anonymous decision -> Allow (if that's the policy).
+
+### Manual Verification
+1.  User A creates decision.
+2.  User B views decision -> "Close" button hidden.
+3.  User A views decision -> "Close" button visible.
+4.  User A clicks Close -> Succeeds.

--- a/stories/US-013-User-Notifications.md
+++ b/stories/US-013-User-Notifications.md
@@ -1,0 +1,16 @@
+# US-013: User Notifications
+
+## Description
+As a decision owner, I want to be notified when there are updates to my decisions (e.g., new arguments added), so that I can stay engaged and monitor the progress.
+
+## Acceptance Criteria
+1.  **Email Notification**: The decision owner receives an email notification when a new argument is added to their decision.
+2.  **Opt-out**: Users can choose to disable notifications in their profile/dashboard.
+3.  **Content**: The email contains the new argument text and a link to the decision.
+
+## Technical Notes
+-   Use Firebase Cloud Functions (Firestore triggers).
+-   Trigger on `onCreate` of an argument document.
+-   Retrieve the parent decision to get the `ownerId`.
+-   Retrieve the user profile (from Auth or a `users` collection) to get the email (or use Auth SDK if possible/allowed).
+-   Use an email sending service (e.g., Firebase Extension "Trigger Email" or Nodemailer with SMTP).

--- a/stories/US-014-Restrict-Closing.md
+++ b/stories/US-014-Restrict-Closing.md
@@ -1,0 +1,14 @@
+# US-014: Restrict Decision Closing
+
+## Description
+As a decision owner, I want to be the only one allowed to close my decision, so that I can control when the voting period ends.
+
+## Acceptance Criteria
+1.  **Owner Only**: If a decision has an owner, only that user can toggle the "Open/Closed" status.
+2.  **UI Feedback**: The "Close Decision" button is hidden or disabled for non-owners.
+3.  **Security**: Backend rules reject status updates from non-owners.
+4.  **Legacy Support**: Anonymous decisions (no owner) might still be closable by anyone (or restricted to creator if we had a way, but likely "anyone" for backward compatibility or locked). *Decision: Allow anyone to close anonymous decisions for now, or lock them.* -> *Assumption: Anonymous decisions remain closable by anyone with the link, or we leave them as is.*
+
+## Technical Notes
+-   Update `firestore.rules`.
+-   Update Frontend to check `currentUser.uid === decision.ownerId`.


### PR DESCRIPTION
## Summary
Adds missing user stories and implementation plans that were identified during roadmap analysis.

## Changes
- ✅ Add US-013: User Notifications
  - Email notifications for decision owners when new arguments are added
  - Includes opt-out functionality
- ✅ Add US-014: Restrict Decision Closing
  - Only decision owners can close their decisions
  - Enforced via Firestore rules and UI

## Related
- Completes roadmap items from v1.4 ("Add possibility to inform users on updates on decisions")
- Completes roadmap items from v1.5 ("Restrict the closing of decisions to the owner")

These stories were missing from the original story set and are now documented for future implementation.