### PR TITLE
chore: Use Service Account for Deployments

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -93,6 +93,10 @@ jobs:
         run: |
           cd functions
           npm ci
+      - name: Authenticate with Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
       - name: Deploy to Staging
         run: |
           npm install -g firebase-tools
@@ -100,9 +104,8 @@ jobs:
           if [ -f apphosting.yaml ]; then
             envsubst < apphosting.yaml > apphosting.yaml.tmp && mv apphosting.yaml.tmp apphosting.yaml
           fi
-          firebase deploy --project staging --token "${{ secrets.FIREBASE_TOKEN }}" --force
+          firebase deploy --project staging --force
         env:
-          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
           NODE_ENV: production
           PORT: 8080
           VITE_FIREBASE_API_KEY: ${{ secrets.VITE_FIREBASE_API_KEY }}
@@ -146,6 +149,10 @@ jobs:
         run: |
           cd functions
           npm ci
+      - name: Authenticate with Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
       - name: Deploy to Production
         run: |
           npm install -g firebase-tools
@@ -153,9 +160,8 @@ jobs:
           if [ -f apphosting.yaml ]; then
             envsubst < apphosting.yaml > apphosting.yaml.tmp && mv apphosting.yaml.tmp apphosting.yaml
           fi
-          firebase deploy --project prod --token "${{ secrets.FIREBASE_TOKEN }}" --force
+          firebase deploy --project prod --force
         env:
-          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
           NODE_ENV: production
           PORT: 8080
           VITE_FIREBASE_API_KEY: ${{ secrets.VITE_FIREBASE_API_KEY }}


### PR DESCRIPTION
Replaces FIREBASE_TOKEN with google-github-actions/auth action using a Service Account for better security.