### PR TITLE
docs: Enforce Strict PR Policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ This document outlines the "Lean Agentic Workflow" adopted for the development o
 ### 5. Review Process
 - **Pull Requests**: All changes should be submitted via Pull Requests (PRs) on GitHub.
 - **Human Review**: The human user acts as the reviewer. The agent must address all feedback before merging.
-- **No Direct Merges**: Avoid pushing directly to the `main` branch for non-trivial changes.
+- **Branch Protection**: NEVER push directly to `main`. ALL changes must be merged via Pull Requests, without exception.
 
 ### 6. Release Preparation
 - **Announcement Post**: For every major and minor release, generate a short blog post announcing the new version.


### PR DESCRIPTION
Updates AGENTS.md to explicitly forbid direct pushes to main, requiring PRs for all changes.