### PR TITLE
fix: Robust Variable Substitution (sed)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -129,7 +129,7 @@ jobs:
           npm install -g firebase-tools
           # Substitute environment variables in apphosting.yaml
           if [ -f apphosting.yaml ]; then
-            envsubst < apphosting.yaml > apphosting.yaml.tmp && mv apphosting.yaml.tmp apphosting.yaml
+            envsubst '$VITE_FIREBASE_API_KEY $VITE_FIREBASE_AUTH_DOMAIN $VITE_FIREBASE_PROJECT_ID $VITE_FIREBASE_STORAGE_BUCKET $VITE_FIREBASE_MESSAGING_SENDER_ID $VITE_FIREBASE_APP_ID $VITE_FIREBASE_MEASUREMENT_ID $VITE_APP_ENV $VITE_COMMIT_HASH' < apphosting.yaml > apphosting.yaml.tmp && mv apphosting.yaml.tmp apphosting.yaml
           fi
           firebase deploy --project staging --force
         env:
@@ -190,7 +190,7 @@ jobs:
           npm install -g firebase-tools
           # Substitute environment variables in apphosting.yaml
           if [ -f apphosting.yaml ]; then
-            envsubst < apphosting.yaml > apphosting.yaml.tmp && mv apphosting.yaml.tmp apphosting.yaml
+            envsubst '$VITE_FIREBASE_API_KEY $VITE_FIREBASE_AUTH_DOMAIN $VITE_FIREBASE_PROJECT_ID $VITE_FIREBASE_STORAGE_BUCKET $VITE_FIREBASE_MESSAGING_SENDER_ID $VITE_FIREBASE_APP_ID $VITE_FIREBASE_MEASUREMENT_ID $VITE_APP_ENV $VITE_COMMIT_HASH' < apphosting.yaml > apphosting.yaml.tmp && mv apphosting.yaml.tmp apphosting.yaml
           fi
           firebase deploy --project prod --force
         env:


### PR DESCRIPTION
Replaces `envsubst` with `sed` to ensure environment variables are correctly substituted in `apphosting.yaml`. This approach explicitly injects GitHub Secrets and context variables directly into the file before deployment.