### PR TITLE
chore: Add Debug to Staging

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -117,6 +117,9 @@ jobs:
         with:
           credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
 
+      - name: Debug Output Service Account
+        run: gcloud auth list
+
       - name: Trigger App Hosting Rollout (Staging)
         if: steps.check_label.outputs.skip_deploy != 'true'
         run: |


### PR DESCRIPTION
Adds the `gcloud auth list` debug step to the Staging deployment job, mirroring the change made to Production.