### PR TITLE
chore: Fix Debug Step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -117,6 +117,9 @@ jobs:
         with:
           credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
 
+      - name: Setup gcloud
+        uses: google-github-actions/setup-gcloud@v2
+
       - name: Debug Output Service Account
         run: gcloud auth list
 
@@ -147,6 +150,9 @@ jobs:
         uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
+
+      - name: Setup gcloud
+        uses: google-github-actions/setup-gcloud@v2
 
       - name: Debug Output Service Account
         run: gcloud auth list


### PR DESCRIPTION
Adds `google-github-actions/setup-gcloud` to ensure `gcloud auth list` actually prints the authenticated service account.