### PR TITLE
fix: configure encryption to be enabled only in production

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -5,3 +5,5 @@ VITE_FIREBASE_STORAGE_BUCKET=your_project_id.appspot.com
 VITE_FIREBASE_MESSAGING_SENDER_ID=your_sender_id
 VITE_FIREBASE_APP_ID=your_app_id
 VITE_FIREBASE_MEASUREMENT_ID=your_measurement_id
+# Encryption enabled only in Production by default. Override locally if needed.
+VITE_ENABLE_ENCRYPTION=false

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -73,6 +73,8 @@ export default defineConfig(({ command }) => {
       __APP_VERSION__: JSON.stringify(packageJson.version),
       __COMMIT_HASH__: JSON.stringify(commitHash),
       __APP_ENV__: JSON.stringify(appEnv || 'Local'),
+      // Enable encryption ONLY in Production
+      'import.meta.env.VITE_ENABLE_ENCRYPTION': JSON.stringify(appEnv === 'Production' ? 'true' : 'false'),
     },
     preview: { allowedHosts: true },
   }


### PR DESCRIPTION
Ensures encryption is enabled only for Production builds (based on appEnv) by setting VITE_ENABLE_ENCRYPTION in vite.config.js. It remains disabled for Staging and Local environments by default.