### PR TITLE
fix: Temporarily Disable Firestore App Check

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -7,22 +7,22 @@ service cloud.firestore {
       allow write: if false; // Only manageable via Cloud Functions
       
       match /finalVotes/{userId} {
-        allow read: if request.app != null;
+        allow read: if true; // TEMPORARY DEBUG: Disable App Check
         allow write: if false;
       }
 
       match /arguments/{argumentId} {
-        allow read: if request.app != null;
+        allow read: if true; // TEMPORARY DEBUG: Disable App Check
         allow write: if false;
         
         match /votes/{userId} {
-          allow read: if request.app != null;
+          allow read: if true; // TEMPORARY DEBUG: Disable App Check
           allow write: if false;
         }
       }
       
       match /participants/{userId} {
-        allow read: if request.app != null;
+        allow read: if true; // TEMPORARY DEBUG: Disable App Check
         allow write: if false;
       }
     }


### PR DESCRIPTION
This PR temporarily changes Firestore rules to `allow read: if true;`.

**Purpose:**
To unblock Staging testing and confirm that the application logic works.

**WARNING:** This makes Staging data publicly readable. Do not merge to Production.