### PR TITLE
fix: Restore Strict App Check (Production Ready)

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -3,26 +3,26 @@ rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
     match /decisions/{decisionId} {
-      allow read: if request.auth != null; // TEMPORARY DEBUG: Bypass App Check, require Auth
+      allow read: if request.app != null;
       allow write: if false; // Only manageable via Cloud Functions
       
       match /finalVotes/{userId} {
-        allow read: if request.auth != null; // TEMPORARY DEBUG: Bypass App Check, require Auth
+        allow read: if request.app != null;
         allow write: if false;
       }
 
       match /arguments/{argumentId} {
-        allow read: if request.auth != null; // TEMPORARY DEBUG: Bypass App Check, require Auth
+        allow read: if request.app != null;
         allow write: if false;
         
         match /votes/{userId} {
-          allow read: if request.auth != null; // TEMPORARY DEBUG: Bypass App Check, require Auth
+          allow read: if request.app != null;
           allow write: if false;
         }
       }
       
       match /participants/{userId} {
-        allow read: if request.auth != null; // TEMPORARY DEBUG: Bypass App Check, require Auth
+        allow read: if request.app != null;
         allow write: if false;
       }
     }


### PR DESCRIPTION
This PR reverts the temporary debug rules and restores strict App Check enforcement (`allow read: if request.app != null;`).

**Why:**
The previous issues on Staging were due to a mismatch between the client code (using V3) and the Enterprise keys.
- **Code Fixed:** `ReCaptchaEnterpriseProvider` is now deployed.
- **Keys Fixed:** You created and registered the Enterprise keys.

**Verification:**
Merge this PR. If Staging *continues to work* with these strict rules, then:
1.  App Check is correctly verifying tokens.
2.  The configuration is **Secure for Production**.

If it breaks again, we know the Key/Client mismatch persists.