### PR TITLE
fix: move dotenv to dependencies for production build

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@vitejs/plugin-react": "^5.1.0",
+    "dotenv": "^17.2.3",
     "firebase": "^12.9.0",
     "firebase-functions": "^7.0.5",
     "html-to-image": "^1.11.13",
@@ -29,7 +30,6 @@
     "vite": "^7.2.2"
   },
   "devDependencies": {
-    "dotenv": "^17.2.3",
     "@eslint/js": "^9.39.2",
     "@playwright/test": "^1.57.0",
     "@testing-library/jest-dom": "^6.9.1",


### PR DESCRIPTION
## Summary
- Moves `dotenv` from `devDependencies` to `dependencies` in `frontend/package.json`

## Root Cause
The cloud build runs `npm ci --quiet --no-fund --no-audit` with `NODE_ENV=production`, which skips installing `devDependencies`. The `generate-sw.js` script imports `dotenv` at build time (as part of `npm run build`), so the package must be available in production installs.

## Test plan
- [ ] Cloud build succeeds on staging deployment
- [ ] `generate-sw.js` runs without `ERR_MODULE_NOT_FOUND` for dotenv

🤖 Generated with [Claude Code](https://claude.com/claude-code)