### PR TITLE
feat: enforce mandatory PR creation in boy-scout agent

### DIFF
--- a/.github/workflows/boy-scout.yml
+++ b/.github/workflows/boy-scout.yml
@@ -85,13 +85,17 @@ jobs:
             ### 3. Execution Steps (Follow these strictly)
             1. **Analyze**: Run `npm run lint` in `frontend` and `functions`. Search for `TODO`s.
             2. **Plan**: Select ONE small, safe task.
-            3. **Implement**: Create a new branch. Apply the fix.
+            3. **Implement**: Create a new branch (`fix/<short-description>`). Apply the fix.
             4. **Verify**: Run tests (`npm test` in the relevant directory).
-            5. **PR**: Push the branch and create a PR.
+            5. **PR** *(mandatory – this step must always run)*:
+               - Push the branch.
+               - Open a pull request via `gh pr create` targeting `main`.
+               - **A pull request MUST be created every run.** If no improvement was found or all fixes were skipped, create a PR titled "Boy-Scout: daily code-quality report" on a branch named `fix/scout-report-<date>` that documents what was analyzed, what was considered, and why no change was made. This ensures full traceability of every agent run.
 
             ### 4. Configuration Parameters
             - `max_daily_changes`: 1 (Strictly one PR per run)
             - `commit_template`: "Boy-Scout: <description>"
+            - `pr_required`: true (A pull request is non-negotiable; the run is considered failed if no PR is opened)
 
             ### 5. Boy‑Scout Manifesto (Daily Reminder)
             ✨ Boy‑Scout Coding Agent: One good deed a day – let’s keep the code cleaner! ✨


### PR DESCRIPTION
## Summary
- Step 5 (PR) is now explicitly marked as **mandatory** — the agent must always open a pull request on every run
- Added a fallback: if no code improvement is found, the agent must open a report PR (`fix/scout-report-<date>`) documenting the analysis and why no change was made
- Added `pr_required: true` config parameter to signal that a run without a PR is considered failed

## Test plan
- [ ] Trigger the boy-scout workflow manually via `workflow_dispatch` and verify a PR is created
- [ ] Confirm that even when the agent finds nothing to fix, a daily code-quality report PR is opened

🤖 Generated with [Claude Code](https://claude.com/claude-code)