### PR TITLE
docs: Decide-O-Mat pitch deck

### DIFF
--- a/docs/architecture.html
+++ b/docs/architecture.html
@@ -38,7 +38,7 @@
 
   <!-- React SPA box -->
   <rect x="28" y="48" width="415" height="182" rx="12" fill="#12122a" stroke="#272745" stroke-width="1.5"/>
-  <text x="48" y="76" font-family="'Alfa Slab One', serif" font-size="15" fill="#b9dd8b">React SPA</text>
+  <text x="48" y="76" font-family="'Open Sans', sans-serif" font-weight="700" font-size="15" fill="#b9dd8b">React SPA</text>
   <text x="48" y="98" font-size="12.5" fill="#aeaec6">Vite build · React Router</text>
   <text x="48" y="116" font-size="12.5" fill="#aeaec6">react-i18next (EN / DE)</text>
   <text x="48" y="134" font-size="12.5" fill="#aeaec6">Firebase SDK  (Auth + Firestore)</text>
@@ -49,7 +49,7 @@
 
   <!-- Web Crypto box -->
   <rect x="477" y="48" width="415" height="182" rx="12" fill="#12122a" stroke="#272745" stroke-width="1.5"/>
-  <text x="497" y="76" font-family="'Alfa Slab One', serif" font-size="15" fill="#c4c3fe">E2EE  —  Web Crypto API</text>
+  <text x="497" y="76" font-family="'Open Sans', sans-serif" font-weight="700" font-size="15" fill="#c4c3fe">E2EE  —  Web Crypto API</text>
   <text x="497" y="98" font-size="12.5" fill="#aeaec6">AES-256 GCM  (client-side only)</text>
   <text x="497" y="116" font-size="12.5" fill="#aeaec6">Encryption key stored in URL #hash</text>
   <text x="497" y="134" font-size="12.5" fill="#aeaec6">Key never sent to server</text>
@@ -76,12 +76,12 @@
 
   <!-- App Hosting bar -->
   <rect x="28" y="324" width="862" height="62" rx="10" fill="#0d1a06" stroke="rgba(185,221,139,.25)" stroke-width="1.5"/>
-  <text x="48" y="349" font-family="'Alfa Slab One', serif" font-size="14" fill="#b9dd8b">App Hosting  (CDN)</text>
+  <text x="48" y="349" font-family="'Open Sans', sans-serif" font-weight="700" font-size="14" fill="#b9dd8b">App Hosting  (CDN)</text>
   <text x="48" y="368" font-size="12.5" fill="#aeaec6">Serves React SPA bundle globally  ·  Global edge network  ·  Automatic HTTPS  ·  Zero-config deploys</text>
 
   <!-- Firebase Auth -->
   <rect x="28" y="408" width="210" height="248" rx="12" fill="#12122a" stroke="#272745" stroke-width="1.5"/>
-  <text x="48" y="436" font-family="'Alfa Slab One', serif" font-size="14" fill="#ffc9ad">Firebase Auth</text>
+  <text x="48" y="436" font-family="'Open Sans', sans-serif" font-weight="700" font-size="14" fill="#ffc9ad">Firebase Auth</text>
   <text x="48" y="458" font-size="12.5" fill="#aeaec6">Google OAuth</text>
   <text x="48" y="476" font-size="12.5" fill="#aeaec6">Email / Password</text>
   <text x="48" y="494" font-size="12.5" fill="#aeaec6">Magic Link (device transfer)</text>
@@ -91,7 +91,7 @@
 
   <!-- Firestore -->
   <rect x="258" y="408" width="230" height="248" rx="12" fill="#12122a" stroke="#272745" stroke-width="1.5"/>
-  <text x="278" y="436" font-family="'Alfa Slab One', serif" font-size="14" fill="#b9dd8b">Firestore</text>
+  <text x="278" y="436" font-family="'Open Sans', sans-serif" font-weight="700" font-size="14" fill="#b9dd8b">Firestore</text>
   <text x="278" y="458" font-size="12.5" fill="#aeaec6">NoSQL document store</text>
   <text x="278" y="476" font-size="12.5" fill="#aeaec6">Real-time listeners (WSS)</text>
   <text x="278" y="494" font-size="12.5" fill="#aeaec6">decisions/ collection</text>
@@ -101,7 +101,7 @@
 
   <!-- Cloud Functions -->
   <rect x="508" y="408" width="382" height="248" rx="12" fill="#12122a" stroke="#272745" stroke-width="1.5"/>
-  <text x="528" y="436" font-family="'Alfa Slab One', serif" font-size="14" fill="#c4c3fe">Cloud Functions</text>
+  <text x="528" y="436" font-family="'Open Sans', sans-serif" font-weight="700" font-size="14" fill="#c4c3fe">Cloud Functions</text>
   <text x="528" y="458" font-size="12.5" fill="#aeaec6">Node.js 20  ·  Stateless  ·  Scale-to-zero</text>
   <text x="528" y="476" font-size="12.5" fill="#aeaec6">deleteUser — GDPR account removal</text>
   <text x="528" y="494" font-size="12.5" fill="#aeaec6">Business logic validation</text>

--- a/docs/architecture.html
+++ b/docs/architecture.html
@@ -111,13 +111,11 @@
 
   <!-- Cloud Functions → Firestore arrow -->
   <line x1="506" y1="510" x2="490" y2="510" stroke="#c4c3fe" stroke-width="1.5" marker-end="url(#arr-p)"/>
-  <text x="493" y="505" font-size="10" fill="#6f6f8e" text-anchor="end">admin</text>
+  <text x="493" y="500" font-size="10" fill="#6f6f8e" text-anchor="end">admin</text>
 
   <!-- Cloud Functions → Firebase Auth arrow -->
   <line x1="506" y1="540" x2="242" y2="540" stroke="#c4c3fe" stroke-width="1.5" stroke-dasharray="4,3" marker-end="url(#arr-p)"/>
 
-  <!-- User bubble -->
-  <circle cx="240" cy="660" r="0" fill="none"/>
 </svg>
 
 </body>

--- a/docs/architecture.html
+++ b/docs/architecture.html
@@ -1,0 +1,124 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Decide-O-Mat — Runtime Architecture</title>
+  <link href="https://fonts.googleapis.com/css2?family=Alfa+Slab+One&family=Open+Sans:wght@400;600;700&display=swap" rel="stylesheet" />
+  <style>
+    body { margin: 0; background: #050509; display: flex; flex-direction: column; align-items: center; padding: 40px 24px 80px; font-family: 'Open Sans', sans-serif; }
+    h1 { font-family: 'Alfa Slab One', serif; color: #b9dd8b; font-size: 28px; margin-bottom: 8px; }
+    p.sub { color: #aeaec6; font-size: 14px; margin-bottom: 40px; }
+    svg { max-width: 100%; height: auto; }
+  </style>
+</head>
+<body>
+  <h1>Decide-O-Mat — Runtime Architecture</h1>
+  <p class="sub">v1.6 · How the system components interact at runtime</p>
+
+<svg width="920" height="680" viewBox="0 0 920 680" xmlns="http://www.w3.org/2000/svg" font-family="'Open Sans', sans-serif">
+  <defs>
+    <marker id="arr-g" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto">
+      <polygon points="0 0, 9 3.5, 0 7" fill="#b9dd8b"/>
+    </marker>
+    <marker id="arr-p" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto">
+      <polygon points="0 0, 9 3.5, 0 7" fill="#c4c3fe"/>
+    </marker>
+    <marker id="arr-m" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto">
+      <polygon points="0 0, 9 3.5, 0 7" fill="#6f6f8e"/>
+    </marker>
+    <marker id="arr-g-rev" markerWidth="9" markerHeight="7" refX="1" refY="3.5" orient="auto">
+      <polygon points="9 0, 0 3.5, 9 7" fill="#b9dd8b"/>
+    </marker>
+  </defs>
+
+  <!-- ── BROWSER ZONE ── -->
+  <rect x="10" y="10" width="900" height="235" rx="16" fill="#1d1d34" stroke="#272745" stroke-width="1.5"/>
+  <text x="28" y="36" font-size="10" font-weight="700" letter-spacing="2.5" fill="#6f6f8e">BROWSER</text>
+
+  <!-- React SPA box -->
+  <rect x="28" y="48" width="415" height="182" rx="12" fill="#12122a" stroke="#272745" stroke-width="1.5"/>
+  <text x="48" y="76" font-family="'Alfa Slab One', serif" font-size="15" fill="#b9dd8b">React SPA</text>
+  <text x="48" y="98" font-size="12.5" fill="#aeaec6">Vite build · React Router</text>
+  <text x="48" y="116" font-size="12.5" fill="#aeaec6">react-i18next (EN / DE)</text>
+  <text x="48" y="134" font-size="12.5" fill="#aeaec6">Firebase SDK  (Auth + Firestore)</text>
+  <text x="48" y="152" font-size="12.5" fill="#aeaec6">CSS Modules · Design tokens</text>
+  <text x="48" y="170" font-size="12.5" fill="#aeaec6">Capability URL access control</text>
+  <text x="48" y="188" font-size="12.5" fill="#aeaec6">html-to-image export</text>
+  <text x="48" y="208" font-size="12.5" fill="#aeaec6">My Decisions · Profile management</text>
+
+  <!-- Web Crypto box -->
+  <rect x="477" y="48" width="415" height="182" rx="12" fill="#12122a" stroke="#272745" stroke-width="1.5"/>
+  <text x="497" y="76" font-family="'Alfa Slab One', serif" font-size="15" fill="#c4c3fe">E2EE  —  Web Crypto API</text>
+  <text x="497" y="98" font-size="12.5" fill="#aeaec6">AES-256 GCM  (client-side only)</text>
+  <text x="497" y="116" font-size="12.5" fill="#aeaec6">Encryption key stored in URL #hash</text>
+  <text x="497" y="134" font-size="12.5" fill="#aeaec6">Key never sent to server</text>
+  <text x="497" y="152" font-size="12.5" fill="#aeaec6">Encrypt question + arguments before write</text>
+  <text x="497" y="170" font-size="12.5" fill="#aeaec6">Decrypt after read from Firestore</text>
+  <text x="497" y="188" font-size="12.5" fill="#aeaec6">localStorage caches key for My Decisions</text>
+  <text x="497" y="208" font-size="12.5" fill="#aeaec6">Server sees only ciphertext</text>
+
+  <!-- SPA ↔ WebCrypto arrow -->
+  <line x1="445" y1="140" x2="475" y2="140" stroke="#c4c3fe" stroke-width="1.5" marker-end="url(#arr-p)" marker-start="url(#arr-g-rev)"/>
+
+  <!-- ── CONNECTOR: SPA → Cloud ── -->
+  <!-- vertical line from browser zone centre down -->
+  <line x1="240" y1="245" x2="240" y2="288" stroke="#6f6f8e" stroke-width="1.5" stroke-dasharray="5,3" marker-end="url(#arr-m)"/>
+  <text x="244" y="270" font-size="11" fill="#6f6f8e">Firebase SDK  (HTTPS / WebSocket)</text>
+
+  <!-- right side: SPA → Cloud Functions -->
+  <line x1="680" y1="245" x2="680" y2="288" stroke="#6f6f8e" stroke-width="1.5" stroke-dasharray="5,3" marker-end="url(#arr-m)"/>
+  <text x="684" y="270" font-size="11" fill="#6f6f8e">HTTPS calls</text>
+
+  <!-- ── GOOGLE CLOUD ZONE ── -->
+  <rect x="10" y="290" width="900" height="378" rx="16" fill="#1d1d34" stroke="#272745" stroke-width="1.5"/>
+  <text x="28" y="316" font-size="10" font-weight="700" letter-spacing="2.5" fill="#6f6f8e">GOOGLE CLOUD  ·  FIREBASE  ·  europe-west4</text>
+
+  <!-- App Hosting bar -->
+  <rect x="28" y="324" width="862" height="62" rx="10" fill="#0d1a06" stroke="rgba(185,221,139,.25)" stroke-width="1.5"/>
+  <text x="48" y="349" font-family="'Alfa Slab One', serif" font-size="14" fill="#b9dd8b">App Hosting  (CDN)</text>
+  <text x="48" y="368" font-size="12.5" fill="#aeaec6">Serves React SPA bundle globally  ·  Global edge network  ·  Automatic HTTPS  ·  Zero-config deploys</text>
+
+  <!-- Firebase Auth -->
+  <rect x="28" y="408" width="210" height="248" rx="12" fill="#12122a" stroke="#272745" stroke-width="1.5"/>
+  <text x="48" y="436" font-family="'Alfa Slab One', serif" font-size="14" fill="#ffc9ad">Firebase Auth</text>
+  <text x="48" y="458" font-size="12.5" fill="#aeaec6">Google OAuth</text>
+  <text x="48" y="476" font-size="12.5" fill="#aeaec6">Email / Password</text>
+  <text x="48" y="494" font-size="12.5" fill="#aeaec6">Magic Link (device transfer)</text>
+  <text x="48" y="512" font-size="12.5" fill="#aeaec6">Anonymous display name</text>
+  <text x="48" y="530" font-size="12.5" fill="#aeaec6">JWT session tokens</text>
+  <text x="48" y="548" font-size="12.5" fill="#aeaec6">GDPR account deletion</text>
+
+  <!-- Firestore -->
+  <rect x="258" y="408" width="230" height="248" rx="12" fill="#12122a" stroke="#272745" stroke-width="1.5"/>
+  <text x="278" y="436" font-family="'Alfa Slab One', serif" font-size="14" fill="#b9dd8b">Firestore</text>
+  <text x="278" y="458" font-size="12.5" fill="#aeaec6">NoSQL document store</text>
+  <text x="278" y="476" font-size="12.5" fill="#aeaec6">Real-time listeners (WSS)</text>
+  <text x="278" y="494" font-size="12.5" fill="#aeaec6">decisions/ collection</text>
+  <text x="278" y="512" font-size="12.5" fill="#aeaec6">arguments/ subcollection</text>
+  <text x="278" y="530" font-size="12.5" fill="#aeaec6">Stores ciphertext only</text>
+  <text x="278" y="548" font-size="12.5" fill="#aeaec6">Security rules enforced</text>
+
+  <!-- Cloud Functions -->
+  <rect x="508" y="408" width="382" height="248" rx="12" fill="#12122a" stroke="#272745" stroke-width="1.5"/>
+  <text x="528" y="436" font-family="'Alfa Slab One', serif" font-size="14" fill="#c4c3fe">Cloud Functions</text>
+  <text x="528" y="458" font-size="12.5" fill="#aeaec6">Node.js 20  ·  Stateless  ·  Scale-to-zero</text>
+  <text x="528" y="476" font-size="12.5" fill="#aeaec6">deleteUser — GDPR account removal</text>
+  <text x="528" y="494" font-size="12.5" fill="#aeaec6">Business logic validation</text>
+  <text x="528" y="512" font-size="12.5" fill="#aeaec6">Rate limiting</text>
+  <text x="528" y="530" font-size="12.5" fill="#aeaec6">Firebase Admin SDK (elevated access)</text>
+  <text x="528" y="548" font-size="12.5" fill="#aeaec6">Firestore + Auth admin operations</text>
+
+  <!-- Cloud Functions → Firestore arrow -->
+  <line x1="506" y1="510" x2="490" y2="510" stroke="#c4c3fe" stroke-width="1.5" marker-end="url(#arr-p)"/>
+  <text x="493" y="505" font-size="10" fill="#6f6f8e" text-anchor="end">admin</text>
+
+  <!-- Cloud Functions → Firebase Auth arrow -->
+  <line x1="506" y1="540" x2="242" y2="540" stroke="#c4c3fe" stroke-width="1.5" stroke-dasharray="4,3" marker-end="url(#arr-p)"/>
+
+  <!-- User bubble -->
+  <circle cx="240" cy="660" r="0" fill="none"/>
+</svg>
+
+</body>
+</html>

--- a/docs/build-diagram.html
+++ b/docs/build-diagram.html
@@ -1,0 +1,191 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Decide-O-Mat — Build System &amp; Firebase Components</title>
+  <link href="https://fonts.googleapis.com/css2?family=Alfa+Slab+One&family=Open+Sans:wght@400;600;700&display=swap" rel="stylesheet" />
+  <style>
+    body { margin: 0; background: #050509; display: flex; flex-direction: column; align-items: center; padding: 40px 24px 80px; font-family: 'Open Sans', sans-serif; }
+    h1 { font-family: 'Alfa Slab One', serif; color: #b9dd8b; font-size: 28px; margin-bottom: 8px; }
+    p.sub { color: #aeaec6; font-size: 14px; margin-bottom: 40px; }
+    svg { max-width: 100%; height: auto; }
+  </style>
+</head>
+<body>
+  <h1>Decide-O-Mat — Build System &amp; Firebase Components</h1>
+  <p class="sub">v1.6 · From local dev to production via GitHub Actions</p>
+
+<svg width="980" height="720" viewBox="0 0 980 720" xmlns="http://www.w3.org/2000/svg" font-family="'Open Sans', sans-serif">
+  <defs>
+    <marker id="arr-g" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto">
+      <polygon points="0 0, 9 3.5, 0 7" fill="#b9dd8b"/>
+    </marker>
+    <marker id="arr-p" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto">
+      <polygon points="0 0, 9 3.5, 0 7" fill="#c4c3fe"/>
+    </marker>
+    <marker id="arr-m" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto">
+      <polygon points="0 0, 9 3.5, 0 7" fill="#6f6f8e"/>
+    </marker>
+    <marker id="arr-o" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto">
+      <polygon points="0 0, 9 3.5, 0 7" fill="#ffc9ad"/>
+    </marker>
+  </defs>
+
+  <!-- ══════════════════════════════════════════
+       ROW 1 — LOCAL DEV + GITHUB + GH ACTIONS
+       ══════════════════════════════════════════ -->
+
+  <!-- LOCAL DEV box -->
+  <rect x="10" y="10" width="260" height="300" rx="14" fill="#1d1d34" stroke="#272745" stroke-width="1.5"/>
+  <text x="26" y="36" font-size="10" font-weight="700" letter-spacing="2.5" fill="#6f6f8e">LOCAL DEVELOPMENT</text>
+
+  <!-- Vite Dev Server -->
+  <rect x="26" y="46" width="228" height="70" rx="9" fill="#12122a" stroke="#272745" stroke-width="1"/>
+  <text x="42" y="68" font-family="'Alfa Slab One', serif" font-size="13" fill="#b9dd8b">Vite Dev Server</text>
+  <text x="42" y="86" font-size="11.5" fill="#aeaec6">Hot Module Replacement</text>
+  <text x="42" y="102" font-size="11.5" fill="#aeaec6">React 19  ·  Port 5173</text>
+
+  <!-- Firebase Emulators -->
+  <rect x="26" y="130" width="228" height="166" rx="9" fill="#12122a" stroke="#272745" stroke-width="1"/>
+  <text x="42" y="152" font-family="'Alfa Slab One', serif" font-size="13" fill="#ffc9ad">Firebase Emulators</text>
+  <text x="42" y="173" font-size="11.5" fill="#aeaec6">Auth Emulator  :9099</text>
+  <text x="42" y="191" font-size="11.5" fill="#aeaec6">Firestore Emulator  :8080</text>
+  <text x="42" y="209" font-size="11.5" fill="#aeaec6">Functions Emulator  :5001</text>
+  <text x="42" y="227" font-size="11.5" fill="#aeaec6">Emulator UI  :4000</text>
+  <text x="42" y="245" font-size="11.5" fill="#aeaec6">ESLint  ·  Vitest  ·  Playwright</text>
+  <text x="42" y="263" font-size="11.5" fill="#aeaec6">firebase.json  ·  .env.local</text>
+
+  <!-- Arrow: Local → GitHub -->
+  <line x1="271" y1="160" x2="348" y2="160" stroke="#b9dd8b" stroke-width="1.5" marker-end="url(#arr-g)"/>
+  <text x="280" y="153" font-size="10.5" fill="#aeaec6">git push</text>
+  <text x="280" y="167" font-size="10.5" fill="#aeaec6">Pull Request</text>
+
+  <!-- GITHUB box -->
+  <rect x="350" y="10" width="240" height="300" rx="14" fill="#1d1d34" stroke="#272745" stroke-width="1.5"/>
+  <text x="366" y="36" font-size="10" font-weight="700" letter-spacing="2.5" fill="#6f6f8e">GITHUB</text>
+
+  <rect x="366" y="46" width="208" height="100" rx="9" fill="#12122a" stroke="#272745" stroke-width="1"/>
+  <text x="382" y="68" font-family="'Alfa Slab One', serif" font-size="13" fill="#b9dd8b">Repository</text>
+  <text x="382" y="89" font-size="11.5" fill="#aeaec6">CI-Till-Krempel/Decide-O-Mat</text>
+  <text x="382" y="107" font-size="11.5" fill="#aeaec6">main branch  ·  feature branches</text>
+  <text x="382" y="125" font-size="11.5" fill="#aeaec6">version tags  (v1.x.x)</text>
+
+  <rect x="366" y="162" width="208" height="134" rx="9" fill="#12122a" stroke="#272745" stroke-width="1"/>
+  <text x="382" y="184" font-family="'Alfa Slab One', serif" font-size="13" fill="#c4c3fe">Actions Triggers</text>
+  <text x="382" y="205" font-size="11.5" fill="#aeaec6">push → main</text>
+  <text x="394" y="221" font-size="11" fill="#6f6f8e">→ deploy Staging</text>
+  <text x="382" y="239" font-size="11.5" fill="#aeaec6">push version tag</text>
+  <text x="394" y="255" font-size="11" fill="#6f6f8e">→ deploy Production</text>
+  <text x="382" y="276" font-size="11.5" fill="#aeaec6">Dependabot  ·  PR checks</text>
+
+  <!-- Arrow: GitHub → GH Actions -->
+  <line x1="591" y1="160" x2="658" y2="160" stroke="#c4c3fe" stroke-width="1.5" marker-end="url(#arr-p)"/>
+  <text x="598" y="153" font-size="10.5" fill="#aeaec6">triggers</text>
+
+  <!-- GITHUB ACTIONS box -->
+  <rect x="660" y="10" width="300" height="300" rx="14" fill="#1d1d34" stroke="#272745" stroke-width="1.5"/>
+  <text x="676" y="36" font-size="10" font-weight="700" letter-spacing="2.5" fill="#6f6f8e">GITHUB ACTIONS  (CI / CD)</text>
+
+  <!-- Lint & Test job -->
+  <rect x="676" y="46" width="268" height="80" rx="9" fill="#12122a" stroke="#272745" stroke-width="1"/>
+  <text x="692" y="68" font-family="'Alfa Slab One', serif" font-size="12" fill="#b9dd8b">Lint &amp; Test</text>
+  <text x="692" y="86" font-size="11.5" fill="#aeaec6">ESLint (frontend/ + functions/)</text>
+  <text x="692" y="104" font-size="11.5" fill="#aeaec6">Vitest unit  ·  Playwright E2E</text>
+
+  <!-- Staging deploy job -->
+  <rect x="676" y="142" width="268" height="80" rx="9" fill="#0d1a06" stroke="rgba(185,221,139,.25)" stroke-width="1"/>
+  <text x="692" y="164" font-family="'Alfa Slab One', serif" font-size="12" fill="#b9dd8b">Deploy → Staging</text>
+  <text x="692" y="182" font-size="11.5" fill="#aeaec6">vite build  +  firebase deploy</text>
+  <text x="692" y="200" font-size="11.5" fill="#aeaec6">Trigger: push to main</text>
+
+  <!-- Prod deploy job -->
+  <rect x="676" y="238" width="268" height="58" rx="9" fill="#1a0d28" stroke="rgba(196,195,254,.25)" stroke-width="1"/>
+  <text x="692" y="260" font-family="'Alfa Slab One', serif" font-size="12" fill="#c4c3fe">Deploy → Production</text>
+  <text x="692" y="278" font-size="11.5" fill="#aeaec6">Trigger: version tag (v*.*.*)</text>
+
+  <!-- ── Arrows: GH Actions → environments ── -->
+  <!-- Staging arrow down-left -->
+  <path d="M 810 325 L 810 380 L 280 380 L 280 418" stroke="#b9dd8b" stroke-width="1.5" fill="none" stroke-dasharray="5,3" marker-end="url(#arr-g)"/>
+  <text x="530" y="374" font-size="10.5" fill="#b9dd8b" text-anchor="middle">push to main → Staging</text>
+
+  <!-- Prod arrow down-right -->
+  <path d="M 870 325 L 870 380 L 720 380 L 720 418" stroke="#c4c3fe" stroke-width="1.5" fill="none" stroke-dasharray="5,3" marker-end="url(#arr-p)"/>
+  <text x="820" y="374" font-size="10.5" fill="#c4c3fe" text-anchor="middle">version tag → Prod</text>
+
+
+  <!-- ══════════════════════════════════════════
+       ROW 2 — STAGING + PRODUCTION ENVIRONMENTS
+       ══════════════════════════════════════════ -->
+
+  <!-- STAGING ENV -->
+  <rect x="10" y="420" width="430" height="288" rx="14" fill="#1d1d34" stroke="rgba(185,221,139,.3)" stroke-width="1.5"/>
+  <text x="26" y="446" font-size="10" font-weight="700" letter-spacing="2.5" fill="#b9dd8b">STAGING ENVIRONMENT</text>
+  <text x="26" y="462" font-size="10" fill="#6f6f8e">decide-o-mat-staging · europe-west4</text>
+
+  <rect x="26" y="472" width="398" height="52" rx="9" fill="#0d1a06" stroke="rgba(185,221,139,.2)" stroke-width="1"/>
+  <text x="42" y="493" font-family="'Alfa Slab One', serif" font-size="12" fill="#b9dd8b">App Hosting (CDN)</text>
+  <text x="42" y="511" font-size="11.5" fill="#aeaec6">decide-o-mat-staging--decide-o-mat-staging.europe-west4.hosted.app</text>
+
+  <rect x="26" y="538" width="180" height="154" rx="9" fill="#12122a" stroke="#272745" stroke-width="1"/>
+  <text x="42" y="559" font-family="'Alfa Slab One', serif" font-size="12" fill="#ffc9ad">Firebase Auth</text>
+  <text x="42" y="578" font-size="11.5" fill="#aeaec6">Staging project</text>
+  <text x="42" y="596" font-size="11.5" fill="#aeaec6">Google OAuth</text>
+  <text x="42" y="614" font-size="11.5" fill="#aeaec6">Email / Password</text>
+  <text x="42" y="632" font-size="11.5" fill="#aeaec6">Magic Links</text>
+  <text x="42" y="670" font-size="10" fill="#6f6f8e">Isolated from Prod</text>
+
+  <rect x="220" y="538" width="105" height="154" rx="9" fill="#12122a" stroke="#272745" stroke-width="1"/>
+  <text x="236" y="559" font-family="'Alfa Slab One', serif" font-size="12" fill="#b9dd8b">Firestore</text>
+  <text x="236" y="578" font-size="11.5" fill="#aeaec6">Staging DB</text>
+  <text x="236" y="596" font-size="11.5" fill="#aeaec6">decisions/</text>
+  <text x="236" y="614" font-size="11.5" fill="#aeaec6">arguments/</text>
+  <text x="236" y="632" font-size="11.5" fill="#aeaec6">Real-time</text>
+
+  <rect x="338" y="538" width="86" height="154" rx="9" fill="#12122a" stroke="#272745" stroke-width="1"/>
+  <text x="346" y="559" font-family="'Alfa Slab One', serif" font-size="11" fill="#c4c3fe">Functions</text>
+  <text x="346" y="578" font-size="11" fill="#aeaec6">Node 20</text>
+  <text x="346" y="596" font-size="11" fill="#aeaec6">deleteUser</text>
+  <text x="346" y="614" font-size="11" fill="#aeaec6">Validation</text>
+  <text x="346" y="632" font-size="11" fill="#aeaec6">Rate limit</text>
+
+  <!-- PRODUCTION ENV -->
+  <rect x="460" y="420" width="508" height="288" rx="14" fill="#1d1d34" stroke="rgba(196,195,254,.3)" stroke-width="1.5"/>
+  <text x="476" y="446" font-size="10" font-weight="700" letter-spacing="2.5" fill="#c4c3fe">PRODUCTION ENVIRONMENT</text>
+  <text x="476" y="462" font-size="10" fill="#6f6f8e">decide-o-mat-prod · europe-west4</text>
+
+  <rect x="476" y="472" width="476" height="52" rx="9" fill="#1a0d28" stroke="rgba(196,195,254,.2)" stroke-width="1"/>
+  <text x="492" y="493" font-family="'Alfa Slab One', serif" font-size="12" fill="#c4c3fe">App Hosting (CDN)</text>
+  <text x="492" y="511" font-size="11.5" fill="#aeaec6">decide-o-mat-prod--decide-o-mat.europe-west4.hosted.app</text>
+
+  <rect x="476" y="538" width="200" height="154" rx="9" fill="#12122a" stroke="#272745" stroke-width="1"/>
+  <text x="492" y="559" font-family="'Alfa Slab One', serif" font-size="12" fill="#ffc9ad">Firebase Auth</text>
+  <text x="492" y="578" font-size="11.5" fill="#aeaec6">Production project</text>
+  <text x="492" y="596" font-size="11.5" fill="#aeaec6">Google OAuth</text>
+  <text x="492" y="614" font-size="11.5" fill="#aeaec6">Email / Password</text>
+  <text x="492" y="632" font-size="11.5" fill="#aeaec6">Magic Links</text>
+  <text x="492" y="670" font-size="10" fill="#6f6f8e">Live user accounts</text>
+
+  <rect x="692" y="538" width="120" height="154" rx="9" fill="#12122a" stroke="#272745" stroke-width="1"/>
+  <text x="708" y="559" font-family="'Alfa Slab One', serif" font-size="12" fill="#b9dd8b">Firestore</text>
+  <text x="708" y="578" font-size="11.5" fill="#aeaec6">Production DB</text>
+  <text x="708" y="596" font-size="11.5" fill="#aeaec6">decisions/</text>
+  <text x="708" y="614" font-size="11.5" fill="#aeaec6">arguments/</text>
+  <text x="708" y="632" font-size="11.5" fill="#aeaec6">Encrypted</text>
+  <text x="708" y="650" font-size="11.5" fill="#aeaec6">Real-time</text>
+
+  <rect x="828" y="538" width="116" height="154" rx="9" fill="#12122a" stroke="#272745" stroke-width="1"/>
+  <text x="838" y="559" font-family="'Alfa Slab One', serif" font-size="11" fill="#c4c3fe">Functions</text>
+  <text x="838" y="578" font-size="11" fill="#aeaec6">Node 20</text>
+  <text x="838" y="596" font-size="11" fill="#aeaec6">deleteUser</text>
+  <text x="838" y="614" font-size="11" fill="#aeaec6">Validation</text>
+  <text x="838" y="632" font-size="11" fill="#aeaec6">Rate limit</text>
+  <text x="838" y="650" font-size="11" fill="#aeaec6">Admin SDK</text>
+
+  <!-- Dependency arrows within prod -->
+  <line x1="691" y1="615" x2="670" y2="615" stroke="#c4c3fe" stroke-width="1" marker-end="url(#arr-p)"/>
+  <line x1="827" y1="600" x2="816" y2="600" stroke="#c4c3fe" stroke-width="1" marker-end="url(#arr-p)"/>
+</svg>
+
+</body>
+</html>

--- a/docs/build-diagram.html
+++ b/docs/build-diagram.html
@@ -42,13 +42,13 @@
 
   <!-- Vite Dev Server -->
   <rect x="26" y="46" width="228" height="70" rx="9" fill="#12122a" stroke="#272745" stroke-width="1"/>
-  <text x="42" y="68" font-family="'Alfa Slab One', serif" font-size="13" fill="#b9dd8b">Vite Dev Server</text>
+  <text x="42" y="68" font-family="'Open Sans', sans-serif" font-weight="700" font-size="13" fill="#b9dd8b">Vite Dev Server</text>
   <text x="42" y="86" font-size="11.5" fill="#aeaec6">Hot Module Replacement</text>
   <text x="42" y="102" font-size="11.5" fill="#aeaec6">React 19  ·  Port 5173</text>
 
   <!-- Firebase Emulators -->
   <rect x="26" y="130" width="228" height="166" rx="9" fill="#12122a" stroke="#272745" stroke-width="1"/>
-  <text x="42" y="152" font-family="'Alfa Slab One', serif" font-size="13" fill="#ffc9ad">Firebase Emulators</text>
+  <text x="42" y="152" font-family="'Open Sans', sans-serif" font-weight="700" font-size="13" fill="#ffc9ad">Firebase Emulators</text>
   <text x="42" y="173" font-size="11.5" fill="#aeaec6">Auth Emulator  :9099</text>
   <text x="42" y="191" font-size="11.5" fill="#aeaec6">Firestore Emulator  :8080</text>
   <text x="42" y="209" font-size="11.5" fill="#aeaec6">Functions Emulator  :5001</text>
@@ -66,13 +66,13 @@
   <text x="366" y="36" font-size="10" font-weight="700" letter-spacing="2.5" fill="#6f6f8e">GITHUB</text>
 
   <rect x="366" y="46" width="208" height="100" rx="9" fill="#12122a" stroke="#272745" stroke-width="1"/>
-  <text x="382" y="68" font-family="'Alfa Slab One', serif" font-size="13" fill="#b9dd8b">Repository</text>
+  <text x="382" y="68" font-family="'Open Sans', sans-serif" font-weight="700" font-size="13" fill="#b9dd8b">Repository</text>
   <text x="382" y="89" font-size="11.5" fill="#aeaec6">CI-Till-Krempel/Decide-O-Mat</text>
   <text x="382" y="107" font-size="11.5" fill="#aeaec6">main branch  ·  feature branches</text>
   <text x="382" y="125" font-size="11.5" fill="#aeaec6">version tags  (v1.x.x)</text>
 
   <rect x="366" y="162" width="208" height="134" rx="9" fill="#12122a" stroke="#272745" stroke-width="1"/>
-  <text x="382" y="184" font-family="'Alfa Slab One', serif" font-size="13" fill="#c4c3fe">Actions Triggers</text>
+  <text x="382" y="184" font-family="'Open Sans', sans-serif" font-weight="700" font-size="13" fill="#c4c3fe">Actions Triggers</text>
   <text x="382" y="205" font-size="11.5" fill="#aeaec6">push → main</text>
   <text x="394" y="221" font-size="11" fill="#6f6f8e">→ deploy Staging</text>
   <text x="382" y="239" font-size="11.5" fill="#aeaec6">push version tag</text>
@@ -89,19 +89,19 @@
 
   <!-- Lint & Test job -->
   <rect x="676" y="46" width="268" height="80" rx="9" fill="#12122a" stroke="#272745" stroke-width="1"/>
-  <text x="692" y="68" font-family="'Alfa Slab One', serif" font-size="12" fill="#b9dd8b">Lint &amp; Test</text>
+  <text x="692" y="68" font-family="'Open Sans', sans-serif" font-weight="700" font-size="12" fill="#b9dd8b">Lint &amp; Test</text>
   <text x="692" y="86" font-size="11.5" fill="#aeaec6">ESLint (frontend/ + functions/)</text>
   <text x="692" y="104" font-size="11.5" fill="#aeaec6">Vitest unit  ·  Playwright E2E</text>
 
   <!-- Staging deploy job -->
   <rect x="676" y="142" width="268" height="80" rx="9" fill="#0d1a06" stroke="rgba(185,221,139,.25)" stroke-width="1"/>
-  <text x="692" y="164" font-family="'Alfa Slab One', serif" font-size="12" fill="#b9dd8b">Deploy → Staging</text>
+  <text x="692" y="164" font-family="'Open Sans', sans-serif" font-weight="700" font-size="12" fill="#b9dd8b">Deploy → Staging</text>
   <text x="692" y="182" font-size="11.5" fill="#aeaec6">vite build  +  firebase deploy</text>
   <text x="692" y="200" font-size="11.5" fill="#aeaec6">Trigger: push to main</text>
 
   <!-- Prod deploy job -->
   <rect x="676" y="238" width="268" height="58" rx="9" fill="#1a0d28" stroke="rgba(196,195,254,.25)" stroke-width="1"/>
-  <text x="692" y="260" font-family="'Alfa Slab One', serif" font-size="12" fill="#c4c3fe">Deploy → Production</text>
+  <text x="692" y="260" font-family="'Open Sans', sans-serif" font-weight="700" font-size="12" fill="#c4c3fe">Deploy → Production</text>
   <text x="692" y="278" font-size="11.5" fill="#aeaec6">Trigger: version tag (v*.*.*)</text>
 
   <!-- ── Arrows: GH Actions → environments ── -->
@@ -124,11 +124,11 @@
   <text x="26" y="462" font-size="10" fill="#6f6f8e">decide-o-mat-staging · europe-west4</text>
 
   <rect x="26" y="472" width="398" height="52" rx="9" fill="#0d1a06" stroke="rgba(185,221,139,.2)" stroke-width="1"/>
-  <text x="42" y="493" font-family="'Alfa Slab One', serif" font-size="12" fill="#b9dd8b">App Hosting (CDN)</text>
+  <text x="42" y="493" font-family="'Open Sans', sans-serif" font-weight="700" font-size="12" fill="#b9dd8b">App Hosting (CDN)</text>
   <text x="42" y="511" font-size="11.5" fill="#aeaec6">decide-o-mat-staging--decide-o-mat-staging.europe-west4.hosted.app</text>
 
   <rect x="26" y="538" width="180" height="154" rx="9" fill="#12122a" stroke="#272745" stroke-width="1"/>
-  <text x="42" y="559" font-family="'Alfa Slab One', serif" font-size="12" fill="#ffc9ad">Firebase Auth</text>
+  <text x="42" y="559" font-family="'Open Sans', sans-serif" font-weight="700" font-size="12" fill="#ffc9ad">Firebase Auth</text>
   <text x="42" y="578" font-size="11.5" fill="#aeaec6">Staging project</text>
   <text x="42" y="596" font-size="11.5" fill="#aeaec6">Google OAuth</text>
   <text x="42" y="614" font-size="11.5" fill="#aeaec6">Email / Password</text>
@@ -136,14 +136,14 @@
   <text x="42" y="670" font-size="10" fill="#6f6f8e">Isolated from Prod</text>
 
   <rect x="220" y="538" width="105" height="154" rx="9" fill="#12122a" stroke="#272745" stroke-width="1"/>
-  <text x="236" y="559" font-family="'Alfa Slab One', serif" font-size="12" fill="#b9dd8b">Firestore</text>
+  <text x="236" y="559" font-family="'Open Sans', sans-serif" font-weight="700" font-size="12" fill="#b9dd8b">Firestore</text>
   <text x="236" y="578" font-size="11.5" fill="#aeaec6">Staging DB</text>
   <text x="236" y="596" font-size="11.5" fill="#aeaec6">decisions/</text>
   <text x="236" y="614" font-size="11.5" fill="#aeaec6">arguments/</text>
   <text x="236" y="632" font-size="11.5" fill="#aeaec6">Real-time</text>
 
   <rect x="338" y="538" width="86" height="154" rx="9" fill="#12122a" stroke="#272745" stroke-width="1"/>
-  <text x="346" y="559" font-family="'Alfa Slab One', serif" font-size="11" fill="#c4c3fe">Functions</text>
+  <text x="346" y="559" font-family="'Open Sans', sans-serif" font-weight="700" font-size="11" fill="#c4c3fe">Functions</text>
   <text x="346" y="578" font-size="11" fill="#aeaec6">Node 20</text>
   <text x="346" y="596" font-size="11" fill="#aeaec6">deleteUser</text>
   <text x="346" y="614" font-size="11" fill="#aeaec6">Validation</text>
@@ -155,11 +155,11 @@
   <text x="476" y="462" font-size="10" fill="#6f6f8e">decide-o-mat-prod · europe-west4</text>
 
   <rect x="476" y="472" width="476" height="52" rx="9" fill="#1a0d28" stroke="rgba(196,195,254,.2)" stroke-width="1"/>
-  <text x="492" y="493" font-family="'Alfa Slab One', serif" font-size="12" fill="#c4c3fe">App Hosting (CDN)</text>
+  <text x="492" y="493" font-family="'Open Sans', sans-serif" font-weight="700" font-size="12" fill="#c4c3fe">App Hosting (CDN)</text>
   <text x="492" y="511" font-size="11.5" fill="#aeaec6">decide-o-mat-prod--decide-o-mat.europe-west4.hosted.app</text>
 
   <rect x="476" y="538" width="200" height="154" rx="9" fill="#12122a" stroke="#272745" stroke-width="1"/>
-  <text x="492" y="559" font-family="'Alfa Slab One', serif" font-size="12" fill="#ffc9ad">Firebase Auth</text>
+  <text x="492" y="559" font-family="'Open Sans', sans-serif" font-weight="700" font-size="12" fill="#ffc9ad">Firebase Auth</text>
   <text x="492" y="578" font-size="11.5" fill="#aeaec6">Production project</text>
   <text x="492" y="596" font-size="11.5" fill="#aeaec6">Google OAuth</text>
   <text x="492" y="614" font-size="11.5" fill="#aeaec6">Email / Password</text>
@@ -167,7 +167,7 @@
   <text x="492" y="670" font-size="10" fill="#6f6f8e">Live user accounts</text>
 
   <rect x="692" y="538" width="120" height="154" rx="9" fill="#12122a" stroke="#272745" stroke-width="1"/>
-  <text x="708" y="559" font-family="'Alfa Slab One', serif" font-size="12" fill="#b9dd8b">Firestore</text>
+  <text x="708" y="559" font-family="'Open Sans', sans-serif" font-weight="700" font-size="12" fill="#b9dd8b">Firestore</text>
   <text x="708" y="578" font-size="11.5" fill="#aeaec6">Production DB</text>
   <text x="708" y="596" font-size="11.5" fill="#aeaec6">decisions/</text>
   <text x="708" y="614" font-size="11.5" fill="#aeaec6">arguments/</text>
@@ -175,7 +175,7 @@
   <text x="708" y="650" font-size="11.5" fill="#aeaec6">Real-time</text>
 
   <rect x="828" y="538" width="116" height="154" rx="9" fill="#12122a" stroke="#272745" stroke-width="1"/>
-  <text x="838" y="559" font-family="'Alfa Slab One', serif" font-size="11" fill="#c4c3fe">Functions</text>
+  <text x="838" y="559" font-family="'Open Sans', sans-serif" font-weight="700" font-size="11" fill="#c4c3fe">Functions</text>
   <text x="838" y="578" font-size="11" fill="#aeaec6">Node 20</text>
   <text x="838" y="596" font-size="11" fill="#aeaec6">deleteUser</text>
   <text x="838" y="614" font-size="11" fill="#aeaec6">Validation</text>

--- a/docs/pitch-deck.html
+++ b/docs/pitch-deck.html
@@ -114,9 +114,10 @@
     .slide-label.orange  { color: var(--accent-orange); }
 
     h2 {
-      font-family: 'Alfa Slab One', serif;
-      font-size: 36px;
-      line-height: 1.15;
+      font-family: 'Open Sans', sans-serif;
+      font-weight: 700;
+      font-size: 34px;
+      line-height: 1.2;
       color: var(--text-base);
     }
 
@@ -262,7 +263,8 @@
     .stats { display: flex; gap: 32px; margin-top: 40px; flex-wrap: wrap; }
     .stat { flex: 1; min-width: 120px; }
     .stat .num {
-      font-family: 'Alfa Slab One', serif;
+      font-family: 'Open Sans', sans-serif;
+      font-weight: 700;
       font-size: 42px;
       color: var(--accent-primary);
       line-height: 1;

--- a/docs/pitch-deck.html
+++ b/docs/pitch-deck.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="Decide-O-Mat Pitch Deck: Collaborative, zero-friction, and end-to-end encrypted decision making for teams." />
   <title>Decide-O-Mat — Pitch Deck</title>
   <link href="https://fonts.googleapis.com/css2?family=Alfa+Slab+One&family=Open+Sans:wght@400;600;700&display=swap" rel="stylesheet" />
   <style>
@@ -300,6 +301,19 @@
     }
     #nav a:hover { background: var(--accent-primary); transform: scale(1.4); }
 
+    /* ── Accessibility ── */
+    .sr-only {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      white-space: nowrap;
+      border-width: 0;
+    }
+
     /* ── Responsive ── */
     @media (max-width: 640px) {
       .slide { padding: 40px 24px; min-height: unset; }
@@ -313,16 +327,16 @@
 <body>
 
 <nav id="nav" aria-label="Slide navigation">
-  <a href="#s1" title="Title"></a>
-  <a href="#s2" title="Problem"></a>
-  <a href="#s3" title="Solution"></a>
-  <a href="#s4" title="Features"></a>
-  <a href="#s5" title="How it works"></a>
-  <a href="#s6" title="Security"></a>
-  <a href="#s7" title="Stack"></a>
-  <a href="#s8" title="Roadmap"></a>
-  <a href="#s9" title="Audience"></a>
-  <a href="#s10" title="CTA"></a>
+  <a href="#s1" title="Title"><span class="sr-only">Slide 1: Title</span></a>
+  <a href="#s2" title="Problem"><span class="sr-only">Slide 2: Problem</span></a>
+  <a href="#s3" title="Solution"><span class="sr-only">Slide 3: Solution</span></a>
+  <a href="#s4" title="Features"><span class="sr-only">Slide 4: Features</span></a>
+  <a href="#s5" title="How it works"><span class="sr-only">Slide 5: How it works</span></a>
+  <a href="#s6" title="Security"><span class="sr-only">Slide 6: Security</span></a>
+  <a href="#s7" title="Stack"><span class="sr-only">Slide 7: Stack</span></a>
+  <a href="#s8" title="Roadmap"><span class="sr-only">Slide 8: Roadmap</span></a>
+  <a href="#s9" title="Audience"><span class="sr-only">Slide 9: Audience</span></a>
+  <a href="#s10" title="CTA"><span class="sr-only">Slide 10: Call to Action</span></a>
 </nav>
 
 <div class="deck">
@@ -367,7 +381,7 @@
     <div class="stats">
       <div class="stat">
         <div class="num">0</div>
-        <div class="desc">Sign-ups required to participate</div>
+        <div class="desc">Sign-up required to participate</div>
       </div>
       <div class="stat">
         <div class="num">E2E</div>
@@ -610,7 +624,7 @@
   <!-- 10. CTA -->
   <section id="s10" class="slide cta-slide">
     <span class="slide-num">10 / 10</span>
-    <div class="logo" style="font-size:44px;">Decide-O-Mat</div>
+    <div class="logo">Decide-O-Mat</div>
     <p class="tagline" style="margin-top:24px; font-size:20px;">
       Structured. Private. Zero friction.<br>
       <strong style="color: var(--text-base);">The democratic way to make group decisions.</strong>

--- a/docs/pitch-deck.html
+++ b/docs/pitch-deck.html
@@ -1,0 +1,629 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Decide-O-Mat — Pitch Deck</title>
+  <link href="https://fonts.googleapis.com/css2?family=Alfa+Slab+One&family=Open+Sans:wght@400;600;700&display=swap" rel="stylesheet" />
+  <style>
+    :root {
+      --bg-base:         #050509;
+      --bg-card:         #1d1d34;
+      --accent-primary:  #b9dd8b;
+      --accent-secondary:#c4c3fe;
+      --accent-orange:   #ffc9ad;
+      --border-outline:  #6f6f8e;
+      --border-card:     #272745;
+      --text-muted:      #aeaec6;
+      --text-base:       #e8e8f0;
+    }
+
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      background: var(--bg-base);
+      color: var(--text-base);
+      font-family: 'Open Sans', sans-serif;
+      font-size: 16px;
+      line-height: 1.6;
+      scroll-behavior: smooth;
+    }
+
+    /* ── Slide container ── */
+    .deck { max-width: 960px; margin: 0 auto; padding: 0 24px 80px; }
+
+    .slide {
+      min-height: 560px;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      padding: 64px 48px;
+      margin-bottom: 4px;
+      border-radius: 24px;
+      position: relative;
+      overflow: hidden;
+    }
+
+    .slide + .slide { margin-top: 32px; }
+
+    /* ── Slide variants ── */
+    .slide-hero {
+      background: linear-gradient(135deg, #0d0d1f 0%, #1a1a38 60%, #0d1a2a 100%);
+      border: 1px solid var(--border-card);
+      text-align: center;
+      align-items: center;
+    }
+
+    .slide-dark {
+      background: var(--bg-card);
+      border: 1px solid var(--border-card);
+    }
+
+    .slide-accent {
+      background: linear-gradient(135deg, #1a2a10 0%, #162214 100%);
+      border: 1px solid rgba(185, 221, 139, 0.25);
+    }
+
+    .slide-purple {
+      background: linear-gradient(135deg, #1a1a38 0%, #12102a 100%);
+      border: 1px solid rgba(196, 195, 254, 0.25);
+    }
+
+    .slide-orange {
+      background: linear-gradient(135deg, #2a1a10 0%, #1e1208 100%);
+      border: 1px solid rgba(255, 201, 173, 0.25);
+    }
+
+    /* ── Slide number ── */
+    .slide-num {
+      position: absolute;
+      top: 24px;
+      right: 32px;
+      font-size: 12px;
+      color: var(--border-outline);
+      letter-spacing: 2px;
+      text-transform: uppercase;
+    }
+
+    /* ── Typography ── */
+    .logo {
+      font-family: 'Alfa Slab One', serif;
+      font-size: 56px;
+      color: var(--accent-primary);
+      letter-spacing: -1px;
+      line-height: 1;
+    }
+
+    .tagline {
+      font-size: 22px;
+      color: var(--text-muted);
+      margin-top: 16px;
+      max-width: 520px;
+    }
+
+    .slide-label {
+      font-size: 11px;
+      font-weight: 600;
+      letter-spacing: 3px;
+      text-transform: uppercase;
+      color: var(--accent-primary);
+      margin-bottom: 16px;
+    }
+
+    .slide-label.purple  { color: var(--accent-secondary); }
+    .slide-label.orange  { color: var(--accent-orange); }
+
+    h2 {
+      font-family: 'Alfa Slab One', serif;
+      font-size: 36px;
+      line-height: 1.15;
+      color: var(--text-base);
+    }
+
+    h3 {
+      font-size: 20px;
+      font-weight: 600;
+      color: var(--text-base);
+      margin-bottom: 8px;
+    }
+
+    p { color: var(--text-muted); margin-bottom: 16px; }
+    p strong { color: var(--text-base); }
+
+    /* ── CTA badge ── */
+    .badge {
+      display: inline-block;
+      padding: 6px 16px;
+      border-radius: 100px;
+      font-size: 13px;
+      font-weight: 600;
+      margin-top: 32px;
+    }
+    .badge-green  { background: rgba(185,221,139,.18); color: var(--accent-primary); border: 1px solid rgba(185,221,139,.35); }
+    .badge-purple { background: rgba(196,195,254,.14); color: var(--accent-secondary); border: 1px solid rgba(196,195,254,.3); }
+    .badge-orange { background: rgba(255,201,173,.14); color: var(--accent-orange);    border: 1px solid rgba(255,201,173,.3); }
+
+    /* ── Grid layouts ── */
+    .grid-2 { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; margin-top: 40px; }
+    .grid-3 { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 20px; margin-top: 40px; }
+
+    /* ── Cards ── */
+    .card {
+      background: rgba(255,255,255,.04);
+      border: 1px solid var(--border-card);
+      border-radius: 16px;
+      padding: 28px;
+    }
+
+    .card-icon {
+      font-size: 32px;
+      margin-bottom: 12px;
+      display: block;
+    }
+
+    /* ── Problem list ── */
+    .problem-list { list-style: none; margin-top: 40px; display: flex; flex-direction: column; gap: 16px; }
+    .problem-list li {
+      display: flex;
+      align-items: flex-start;
+      gap: 16px;
+      padding: 20px 24px;
+      background: rgba(255,255,255,.03);
+      border-radius: 12px;
+      border-left: 3px solid var(--accent-orange);
+    }
+    .problem-list li .ico { font-size: 24px; flex-shrink: 0; }
+    .problem-list li p { margin: 0; }
+
+    /* ── How it works steps ── */
+    .steps { display: flex; flex-direction: column; gap: 20px; margin-top: 36px; }
+    .step {
+      display: flex;
+      align-items: flex-start;
+      gap: 20px;
+    }
+    .step-num {
+      width: 40px;
+      height: 40px;
+      border-radius: 50%;
+      background: var(--accent-primary);
+      color: #0d1a08;
+      font-weight: 700;
+      font-size: 16px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      flex-shrink: 0;
+    }
+    .step-body h3 { margin-bottom: 4px; color: var(--text-base); }
+    .step-body p  { margin: 0; }
+
+    /* ── Roadmap timeline ── */
+    .timeline { margin-top: 36px; display: flex; flex-direction: column; gap: 0; }
+    .timeline-row {
+      display: flex;
+      gap: 0;
+      align-items: stretch;
+    }
+    .timeline-left {
+      width: 80px;
+      text-align: right;
+      padding-right: 20px;
+      flex-shrink: 0;
+      padding-top: 2px;
+    }
+    .timeline-left .ver {
+      font-size: 12px;
+      font-weight: 700;
+      color: var(--accent-secondary);
+      letter-spacing: 1px;
+    }
+    .timeline-track {
+      width: 2px;
+      background: var(--border-card);
+      position: relative;
+      flex-shrink: 0;
+    }
+    .timeline-track::before {
+      content: '';
+      width: 10px;
+      height: 10px;
+      border-radius: 50%;
+      background: var(--accent-secondary);
+      position: absolute;
+      top: 4px;
+      left: -4px;
+    }
+    .timeline-content {
+      padding: 0 0 28px 20px;
+      flex: 1;
+    }
+    .timeline-content h3 { font-size: 16px; margin-bottom: 4px; }
+    .timeline-content p  { font-size: 14px; margin: 0; }
+
+    .done .timeline-track::before { background: var(--accent-primary); }
+    .done .ver { color: var(--accent-primary); }
+    .future .timeline-track::before { background: var(--border-outline); }
+    .future .ver { color: var(--text-muted); }
+
+    /* ── Security callout ── */
+    .security-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 20px; margin-top: 36px; }
+    .sec-item {
+      display: flex;
+      align-items: flex-start;
+      gap: 12px;
+      padding: 20px;
+      background: rgba(255,255,255,.04);
+      border-radius: 12px;
+    }
+    .sec-ico { font-size: 28px; flex-shrink: 0; }
+
+    /* ── Stat callout ── */
+    .stats { display: flex; gap: 32px; margin-top: 40px; flex-wrap: wrap; }
+    .stat { flex: 1; min-width: 120px; }
+    .stat .num {
+      font-family: 'Alfa Slab One', serif;
+      font-size: 42px;
+      color: var(--accent-primary);
+      line-height: 1;
+    }
+    .stat .desc { font-size: 14px; color: var(--text-muted); margin-top: 6px; }
+
+    /* ── CTA slide ── */
+    .cta-slide {
+      text-align: center;
+      align-items: center;
+      background: linear-gradient(145deg, #0c1a06 0%, #050509 50%, #0c0c28 100%);
+      border: 1px solid var(--border-card);
+    }
+
+    /* ── Nav dots ── */
+    #nav {
+      position: fixed;
+      right: 20px;
+      top: 50%;
+      transform: translateY(-50%);
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+      z-index: 100;
+    }
+    #nav a {
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+      background: var(--border-outline);
+      display: block;
+      transition: background .2s, transform .2s;
+    }
+    #nav a:hover { background: var(--accent-primary); transform: scale(1.4); }
+
+    /* ── Responsive ── */
+    @media (max-width: 640px) {
+      .slide { padding: 40px 24px; min-height: unset; }
+      .grid-2, .grid-3, .security-grid { grid-template-columns: 1fr; }
+      .logo { font-size: 40px; }
+      h2 { font-size: 28px; }
+      #nav { display: none; }
+    }
+  </style>
+</head>
+<body>
+
+<nav id="nav" aria-label="Slide navigation">
+  <a href="#s1" title="Title"></a>
+  <a href="#s2" title="Problem"></a>
+  <a href="#s3" title="Solution"></a>
+  <a href="#s4" title="Features"></a>
+  <a href="#s5" title="How it works"></a>
+  <a href="#s6" title="Security"></a>
+  <a href="#s7" title="Stack"></a>
+  <a href="#s8" title="Roadmap"></a>
+  <a href="#s9" title="Audience"></a>
+  <a href="#s10" title="CTA"></a>
+</nav>
+
+<div class="deck">
+
+  <!-- 1. Title -->
+  <section id="s1" class="slide slide-hero">
+    <span class="slide-num">01 / 10</span>
+    <div class="logo">Decide-O-Mat</div>
+    <p class="tagline">Collaborative decision-making — frictionless, encrypted, and built for the modern web.</p>
+    <span class="badge badge-green">v1.6 · 2026</span>
+  </section>
+
+  <!-- 2. Problem -->
+  <section id="s2" class="slide slide-orange">
+    <span class="slide-num">02 / 10</span>
+    <div class="slide-label orange">The Problem</div>
+    <h2>Group decisions are messy &amp; slow</h2>
+    <ul class="problem-list">
+      <li>
+        <span class="ico">💬</span>
+        <p><strong>Endless chat threads.</strong> Pros and cons buried in group chats, emails, or Slack messages nobody can find later.</p>
+      </li>
+      <li>
+        <span class="ico">🔒</span>
+        <p><strong>Privacy concerns.</strong> Sensitive decisions shared through platforms that scan content or require you to hand over your data.</p>
+      </li>
+      <li>
+        <span class="ico">🚧</span>
+        <p><strong>Friction kills participation.</strong> Heavyweight tools require sign-ups, installs, and onboarding — most people don't bother.</p>
+      </li>
+    </ul>
+  </section>
+
+  <!-- 3. Solution -->
+  <section id="s3" class="slide slide-accent">
+    <span class="slide-num">03 / 10</span>
+    <div class="slide-label">The Solution</div>
+    <h2>One link. Everyone decides.</h2>
+    <p style="margin-top:20px; font-size:18px;">
+      Decide-O-Mat is a <strong>zero-friction collaborative decision tool</strong>: create a decision, share the link, let your group add arguments and cast votes — no account needed.
+    </p>
+    <div class="stats">
+      <div class="stat">
+        <div class="num">0</div>
+        <div class="desc">Sign-ups required to participate</div>
+      </div>
+      <div class="stat">
+        <div class="num">E2E</div>
+        <div class="desc">AES-256 encrypted — even the server can't read your data</div>
+      </div>
+      <div class="stat">
+        <div class="num">2</div>
+        <div class="desc">Languages supported (EN / DE)</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- 4. Core Features -->
+  <section id="s4" class="slide slide-dark">
+    <span class="slide-num">04 / 10</span>
+    <div class="slide-label">Core Features</div>
+    <h2>Everything a decision needs</h2>
+    <div class="grid-3">
+      <div class="card">
+        <span class="card-icon">📝</span>
+        <h3>Create &amp; Share</h3>
+        <p>Post your question and instantly get a shareable URL. No setup.</p>
+      </div>
+      <div class="card">
+        <span class="card-icon">⚖️</span>
+        <h3>Pro / Con Arguments</h3>
+        <p>Participants add arguments for and against. Arguments are attributed to the person who wrote them.</p>
+      </div>
+      <div class="card">
+        <span class="card-icon">👍</span>
+        <h3>Argument Voting</h3>
+        <p>Upvote and downvote individual arguments. Net scores show what the group actually values.</p>
+      </div>
+      <div class="card">
+        <span class="card-icon">🗳️</span>
+        <h3>Final Yes / No Vote</h3>
+        <p>End with a structured vote — should we do it or not?</p>
+      </div>
+      <div class="card">
+        <span class="card-icon">📊</span>
+        <h3>Real-Time Results</h3>
+        <p>Live score updates via Firestore. See the consensus form as it happens.</p>
+      </div>
+      <div class="card">
+        <span class="card-icon">🖼️</span>
+        <h3>Export as Image</h3>
+        <p>Capture and share the final result as a visual summary.</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- 5. How it works -->
+  <section id="s5" class="slide slide-purple">
+    <span class="slide-num">05 / 10</span>
+    <div class="slide-label purple">How It Works</div>
+    <h2>Three steps, one decision</h2>
+    <div class="steps">
+      <div class="step">
+        <div class="step-num">1</div>
+        <div class="step-body">
+          <h3>Create your decision</h3>
+          <p>Enter a question on the home page. The decision is encrypted with a key stored only in the URL hash — invisible to the server.</p>
+        </div>
+      </div>
+      <div class="step">
+        <div class="step-num">2</div>
+        <div class="step-body">
+          <h3>Share the link</h3>
+          <p>Send the URL to anyone. They open it, enter a display name, and start adding pros and cons — no account required.</p>
+        </div>
+      </div>
+      <div class="step">
+        <div class="step-num">3</div>
+        <div class="step-body">
+          <h3>Vote &amp; decide</h3>
+          <p>Arguments are voted on in real time. Cast the final Yes / No vote, close the decision, and export the result.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- 6. Security & Privacy -->
+  <section id="s6" class="slide slide-dark">
+    <span class="slide-num">06 / 10</span>
+    <div class="slide-label purple">Security &amp; Privacy</div>
+    <h2>Private by design</h2>
+    <p style="margin-top:12px;">The encryption key lives in the URL fragment (<code>#…</code>). It never reaches the server — only people with the link can read the content.</p>
+    <div class="security-grid">
+      <div class="sec-item">
+        <span class="sec-ico">🔐</span>
+        <div>
+          <h3>AES-256 E2EE</h3>
+          <p>Questions, arguments, and votes are encrypted client-side using the Web Crypto API.</p>
+        </div>
+      </div>
+      <div class="sec-item">
+        <span class="sec-ico">🌐</span>
+        <div>
+          <h3>Capability URLs</h3>
+          <p>The URL itself is the access credential. Share it to grant access; revoke access by not sharing it.</p>
+        </div>
+      </div>
+      <div class="sec-item">
+        <span class="sec-ico">🛡️</span>
+        <div>
+          <h3>GDPR Compliant</h3>
+          <p>Full account deletion, no third-party trackers, data stored in EU (europe-west4).</p>
+        </div>
+      </div>
+      <div class="sec-item">
+        <span class="sec-ico">🪪</span>
+        <div>
+          <h3>Identity without friction</h3>
+          <p>Firebase Auth with Google or Email. Magic links let signed-in users reclaim decisions across devices.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- 7. Tech Stack -->
+  <section id="s7" class="slide slide-dark">
+    <span class="slide-num">07 / 10</span>
+    <div class="slide-label">Technology</div>
+    <h2>Modern, serverless, scales to zero</h2>
+    <div class="grid-2" style="margin-top:32px;">
+      <div class="card">
+        <span class="card-icon">⚛️</span>
+        <h3>Frontend</h3>
+        <p>React 19 · Vite · React Router · react-i18next · CSS Modules · Web Crypto API</p>
+      </div>
+      <div class="card">
+        <span class="card-icon">☁️</span>
+        <h3>Backend</h3>
+        <p>Google Cloud Functions (Node.js 20) · Firebase Admin SDK · Stateless &amp; serverless</p>
+      </div>
+      <div class="card">
+        <span class="card-icon">🗄️</span>
+        <h3>Database &amp; Hosting</h3>
+        <p>Cloud Firestore (real-time, NoSQL) · Firebase Hosting · Google Cloud App Hosting (CDN)</p>
+      </div>
+      <div class="card">
+        <span class="card-icon">🤖</span>
+        <h3>CI / CD</h3>
+        <p>GitHub Actions · Vitest · Playwright E2E · ESLint · Auto-deploy to Staging &amp; Prod</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- 8. Roadmap -->
+  <section id="s8" class="slide slide-purple">
+    <span class="slide-num">08 / 10</span>
+    <div class="slide-label purple">Roadmap</div>
+    <h2>Where we are &amp; where we're going</h2>
+    <div class="timeline">
+
+      <div class="timeline-row done">
+        <div class="timeline-left"><span class="ver">v1.0–1.2</span></div>
+        <div class="timeline-track"></div>
+        <div class="timeline-content">
+          <h3>MVP — Nov 2025</h3>
+          <p>Create, share, add arguments, vote, view results, export image, close decisions, final Yes/No vote.</p>
+        </div>
+      </div>
+
+      <div class="timeline-row done">
+        <div class="timeline-left"><span class="ver">v1.3–1.5</span></div>
+        <div class="timeline-track"></div>
+        <div class="timeline-content">
+          <h3>Identity &amp; Auth — Dec 2025</h3>
+          <p>Display names, Firebase Auth (Google + Email), anonymous identity, magic link device transfer, My Decisions page, profile management.</p>
+        </div>
+      </div>
+
+      <div class="timeline-row done">
+        <div class="timeline-left"><span class="ver">v1.6</span></div>
+        <div class="timeline-track"></div>
+        <div class="timeline-content">
+          <h3>Design Overhaul — Feb 2026</h3>
+          <p>Dark design system, Figma token architecture, full responsive redesign of all pages, i18n (EN/DE).</p>
+        </div>
+      </div>
+
+      <div class="timeline-row">
+        <div class="timeline-left"><span class="ver">v1.7</span></div>
+        <div class="timeline-track"></div>
+        <div class="timeline-content">
+          <h3>Participants &amp; Notifications</h3>
+          <p>Real-time participant list, notification toggles, owner badges.</p>
+        </div>
+      </div>
+
+      <div class="timeline-row">
+        <div class="timeline-left"><span class="ver">v1.8</span></div>
+        <div class="timeline-track"></div>
+        <div class="timeline-content">
+          <h3>Private Decisions</h3>
+          <p>Choose open vs. private at creation time, participant access management, owner-only close.</p>
+        </div>
+      </div>
+
+      <div class="timeline-row future">
+        <div class="timeline-left"><span class="ver">v2.0</span></div>
+        <div class="timeline-track"></div>
+        <div class="timeline-content">
+          <h3>Multi-Option Decisions</h3>
+          <p>3+ options each with their own pros/cons. Ranked-choice voting.</p>
+        </div>
+      </div>
+
+    </div>
+  </section>
+
+  <!-- 9. Who it's for -->
+  <section id="s9" class="slide slide-accent">
+    <span class="slide-num">09 / 10</span>
+    <div class="slide-label">Who It's For</div>
+    <h2>Any group with a decision to make</h2>
+    <div class="grid-3" style="margin-top:32px;">
+      <div class="card">
+        <span class="card-icon">👥</span>
+        <h3>Friends &amp; Families</h3>
+        <p>Where to eat, which movie to watch, what holiday to book — decide together, fast.</p>
+      </div>
+      <div class="card">
+        <span class="card-icon">💼</span>
+        <h3>Teams &amp; Organizations</h3>
+        <p>Tech stack choices, hiring decisions, project direction — structured reasoning, not gut feel.</p>
+      </div>
+      <div class="card">
+        <span class="card-icon">🔒</span>
+        <h3>Privacy-Conscious Users</h3>
+        <p>Sensitive personal or business decisions that you don't want stored on a third-party server in plain text.</p>
+      </div>
+    </div>
+    <div style="margin-top: 32px; padding: 20px 24px; background: rgba(255,255,255,.04); border-radius: 12px; border-left: 3px solid var(--accent-primary);">
+      <p style="margin:0;"><strong>Core value:</strong> The tool gets out of the way. Open a URL, contribute, decide. No sign-up, no onboarding, no friction.</p>
+    </div>
+  </section>
+
+  <!-- 10. CTA -->
+  <section id="s10" class="slide cta-slide">
+    <span class="slide-num">10 / 10</span>
+    <div class="logo" style="font-size:44px;">Decide-O-Mat</div>
+    <p class="tagline" style="margin-top:24px; font-size:20px;">
+      Structured. Private. Zero friction.<br>
+      <strong style="color: var(--text-base);">The democratic way to make group decisions.</strong>
+    </p>
+    <div style="display:flex; gap:16px; flex-wrap:wrap; justify-content:center; margin-top:40px;">
+      <span class="badge badge-green">Open Source</span>
+      <span class="badge badge-purple">End-to-End Encrypted</span>
+      <span class="badge badge-orange">No Login Required</span>
+    </div>
+    <p style="margin-top: 48px; font-size: 14px; color: var(--border-outline);">
+      Built by Antigravity &mdash; 2026
+    </p>
+  </section>
+
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Adds `docs/pitch-deck.html` — a standalone 10-slide pitch deck styled with the v1.6 dark design system tokens (Alfa Slab One + Open Sans, Figma color tokens)
- Covers problem statement, solution, core features, user flow, security model (E2EE), tech stack, roadmap, and target audience
- No dependencies — opens directly in any browser

## Test plan

- [ ] Open `docs/pitch-deck.html` in a browser and verify all 10 slides render correctly
- [ ] Check nav dots on the right side work as scroll anchors
- [ ] Verify responsive layout on mobile viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)