### PR TITLE
fix: add GEMINI_CLI_TRUST_WORKSPACE to all Gemini CLI workflow steps

### DIFF
--- a/.github/workflows/boy-scout.yml
+++ b/.github/workflows/boy-scout.yml
@@ -44,6 +44,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           REPOSITORY: ${{ github.repository }}
+          GEMINI_CLI_TRUST_WORKSPACE: 'true'
         with:
           gemini_api_key: ${{ secrets.GEMINI_CLI_CODE_REVIEW_AGENT }}
           prompt: |

--- a/.github/workflows/gemini-codereview.yml
+++ b/.github/workflows/gemini-codereview.yml
@@ -39,6 +39,7 @@ jobs:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
           REPOSITORY: ${{ github.repository }}
+          GEMINI_CLI_TRUST_WORKSPACE: 'true'
         with:
           gemini_api_key: ${{ secrets.GEMINI_CLI_CODE_REVIEW_AGENT }}
           prompt: |

--- a/.github/workflows/gemini-issue-triager.yml
+++ b/.github/workflows/gemini-issue-triager.yml
@@ -28,6 +28,7 @@ jobs:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           REPOSITORY: ${{ github.repository }}
+          GEMINI_CLI_TRUST_WORKSPACE: 'true'
         with:
           gemini_api_key: ${{ secrets.GEMINI_CLI_CODE_REVIEW_AGENT }}
           prompt: |


### PR DESCRIPTION
Repository-level environment variables are not automatically injected
into GitHub Actions steps — the env must be declared explicitly in each
step. Added GEMINI_CLI_TRUST_WORKSPACE: 'true' to the env blocks of the
Gemini Code Review, Boy-Scout Agent, and Gemini Issue Triager steps so
the CLI accepts the headless/automated execution context.

https://claude.ai/code/session_018ozrkZCq3boABUcHw4qvx4