### PR TITLE
docs: fix out-of-order setup steps in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,12 +104,6 @@ The Service Account used for GitHub Actions deployments (`FIREBASE_SERVICE_ACCOU
     VITE_RECAPTCHA_SITE_KEY=...
     ```
 
-5.  **Configure App Check (Local Debug Token)**:
-    *   Start the app (`npm run dev`).
-    *   Open the browser console to find the **App Check debug token**.
-    *   Add this token to the Firebase Console > App Check > Manage debug tokens.
-    *   *See [Environment Configuration](docs/environments.md) for details.*
-
 4.  **Start Development Server**:
     *   **Terminal 1 (Emulators)**:
         ```bash
@@ -120,6 +114,11 @@ The Service Account used for GitHub Actions deployments (`FIREBASE_SERVICE_ACCOU
         cd frontend
         npm run dev
         ```
+
+5.  **Configure App Check (Local Debug Token)**:
+    *   With the app running (from the previous step), open the browser console to find the **App Check debug token**.
+    *   Add this token to the Firebase Console > App Check > Manage debug tokens.
+    *   *See [Environment Configuration](docs/environments.md) for details.*
 
 ## Development Resources
 


### PR DESCRIPTION
## Summary
- "Configure App Check" (step 5) was physically placed *before* "Start Development Server" (step 4), and its own first bullet ("Start the app") assumed the dev server was already running — wrong both in numbering and logical order.
- Swapped the two blocks so step 4 (start the server) precedes step 5 (find the App Check debug token in the now-running app's console).

Fixes #103

## Test plan
- [x] Read the surrounding README section to confirm no other steps reference this ordering
- Doc-only change, no code affected