### PR TITLE
fix(functions): remove leftover debugAppCheck function

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -18,19 +18,6 @@ const db = admin.firestore();
  */
 const {enforceAppCheck} = require("./config");
 
-exports.debugAppCheck = onCall({cors: true, enforceAppCheck: false}, async (request) => {
-  // This endpoint is only available outside of production to prevent
-  // information disclosure of auth/App Check internals.
-  if (process.env.GCLOUD_PROJECT === "decide-o-mat") {
-    throw new HttpsError("not-found", "Not available.");
-  }
-  return {
-    app: request.app || null,
-    auth: request.auth || null,
-    enforceAppCheckConfig: enforceAppCheck,
-  };
-});
-
 exports.createDecision = onCall({cors: true, enforceAppCheck: enforceAppCheck}, async (request) => {
   if (!request.auth) {
     throw new HttpsError("unauthenticated", "The function must be called while authenticated.");


### PR DESCRIPTION
## Summary
- Removes the \`debugAppCheck\` Cloud Function (\`functions/index.js\`), a debug-only endpoint (\`enforceAppCheck: false\`) that already 404s in production but was never cleaned up from the deployed function set.
- Confirmed no remaining references in either \`functions/\` or \`frontend/src\` (the frontend call site was already removed previously).

Fixes #256

## Test plan
- [x] \`npm run lint\` in \`functions/\` passes
- [x] \`grep -rn "debugAppCheck"\` across functions and frontend confirms no remaining references