### PR TITLE
fix(decision): disable Close/Share actions while a vote is in flight

### DIFF
--- a/frontend/src/components/FAB.jsx
+++ b/frontend/src/components/FAB.jsx
@@ -9,13 +9,14 @@ function ShareIcon() {
     );
 }
 
-export default function FAB({ onClick, label }) {
+export default function FAB({ onClick, label, disabled }) {
     return (
         <button
             className={styles.fab}
             onClick={onClick}
             aria-label={label}
             type="button"
+            disabled={disabled}
         >
             <ShareIcon />
         </button>

--- a/frontend/src/components/FAB.module.css
+++ b/frontend/src/components/FAB.module.css
@@ -17,6 +17,11 @@
   transition: opacity 0.2s;
 }
 
-.fab:hover {
+.fab:hover:not(:disabled) {
   opacity: 0.9;
+}
+
+.fab:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
 }

--- a/frontend/src/components/StatementCard.jsx
+++ b/frontend/src/components/StatementCard.jsx
@@ -21,7 +21,7 @@ function HeartOutlineIcon() {
     );
 }
 
-export default function StatementCard({ argument, decisionId, readOnly, canVote, participantMap, encryptionKey, onVoteChange, onNameRequired, onError }) {
+export default function StatementCard({ argument, decisionId, readOnly, canVote, participantMap, encryptionKey, onVoteChange, onVotingStateChange, onNameRequired, onError }) {
     const { t } = useTranslation();
     const { user } = useUser();
     const [votes, setVotes] = useState([]);
@@ -52,6 +52,7 @@ export default function StatementCard({ argument, decisionId, readOnly, canVote,
         }
 
         setVoting(true);
+        onVotingStateChange?.(argument.id, true);
         try {
             if (user.displayName && !participantMap.has(user.userId)) {
                 try {
@@ -68,6 +69,7 @@ export default function StatementCard({ argument, decisionId, readOnly, canVote,
             if (onError) onError(t('argumentItem.errorVoteFailed'));
         } finally {
             setVoting(false);
+            onVotingStateChange?.(argument.id, false);
         }
     };
 

--- a/frontend/src/pages/Decision.jsx
+++ b/frontend/src/pages/Decision.jsx
@@ -47,6 +47,7 @@ function Decision() {
     const [activeColumn, setActiveColumn] = useState(null); // null | 'pro' | 'con'
     const [submittingArgument, setSubmittingArgument] = useState(false);
     const [votedArgIds, setVotedArgIds] = useState(new Set());
+    const [votingArgIds, setVotingArgIds] = useState(new Set());
     const [notificationsEnabled, setNotificationsEnabled] = useState(
         () => 'Notification' in window && Notification.permission === 'granted'
     );
@@ -289,6 +290,15 @@ function Decision() {
         });
     }, []);
 
+    const handleVotingStateChange = useCallback((argId, isVoting) => {
+        setVotingArgIds(prev => {
+            const newSet = new Set(prev);
+            if (isVoting) newSet.add(argId);
+            else newSet.delete(argId);
+            return newSet;
+        });
+    }, []);
+
     const isOwner = decision?.ownerId === user?.userId;
 
     const handleToggleStatus = async () => {
@@ -339,6 +349,7 @@ function Decision() {
     if (!decision) return <div className={styles.notFound}>{t('decision.notFound')}</div>;
 
     const isClosed = decision.status === 'closed';
+    const isVotingInProgress = !!votingTarget || votingArgIds.size > 0;
     const yesVotes = decision.yesVotes || 0;
     const noVotes = decision.noVotes || 0;
     const totalVotes = yesVotes + noVotes;
@@ -428,6 +439,7 @@ function Decision() {
                         <button
                             className={styles.toolbarBtn}
                             onClick={handleToggleStatus}
+                            disabled={isVotingInProgress}
                             type="button"
                         >
                             <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
@@ -487,6 +499,7 @@ function Decision() {
                                 participantMap={participantMap}
                                 encryptionKey={encryptionKey}
                                 onVoteChange={handleVoteChange}
+                                onVotingStateChange={handleVotingStateChange}
                                 onNameRequired={(argId) => { setPendingAction({ type: 'argVote', argumentId: argId }); setShowNamePrompt(true); }}
                                 onError={(msg) => setToast({ message: msg, type: 'error' })}
                             />
@@ -517,6 +530,7 @@ function Decision() {
                                 participantMap={participantMap}
                                 encryptionKey={encryptionKey}
                                 onVoteChange={handleVoteChange}
+                                onVotingStateChange={handleVotingStateChange}
                                 onNameRequired={(argId) => { setPendingAction({ type: 'argVote', argumentId: argId }); setShowNamePrompt(true); }}
                                 onError={(msg) => setToast({ message: msg, type: 'error' })}
                             />
@@ -537,6 +551,7 @@ function Decision() {
             <FAB
                 onClick={handleCopyLink}
                 label={t('decision.copyLinkButton')}
+                disabled={isVotingInProgress}
             />
 
             {showEditModal && (

--- a/frontend/src/pages/Decision.module.css
+++ b/frontend/src/pages/Decision.module.css
@@ -76,6 +76,11 @@
   color: var(--color-accent-secondary);
 }
 
+.toolbarBtn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 .toolbarBtnActive {
   border-color: var(--color-accent-primary);
   color: var(--color-accent-primary);


### PR DESCRIPTION
## Summary
- Argument/final vote buttons already disabled themselves while their own request was in flight, but the Close Decision button and the Share FAB stayed clickable during that window — inconsistent, and allowed closing/sharing mid-vote.
- Added a shared `isVotingInProgress` flag in `Decision.jsx` (`!!votingTarget || votingArgIds.size > 0`), combining the existing final-vote state with a newly-lifted per-argument voting state (`StatementCard` now calls a new `onVotingStateChange(argId, isVoting)` callback instead of only tracking `voting` locally).
- Wired `disabled={isVotingInProgress}` into the Close/Reopen toolbar button and the `FAB` (Share) component.
- `FAB.jsx` had no `disabled` prop at all — added it, plus matching `:disabled` styling in `FAB.module.css` (same opacity/cursor pattern already used in `ElectionHero.module.css`).

Fixes #94

Note: this issue also mentioned a "Download/Share Image" button, but that feature doesn't currently exist in the app at all (filed separately as #342) — nothing to disable there since it isn't rendered.

## Test plan
- [x] `npm run lint` passes
- [x] Full frontend test suite passes (149/149)
- [ ] Manual: start a final vote, confirm Close Decision and Share buttons are disabled until the vote request resolves; same for voting on an individual argument