### PR TITLE
feat(argument): allow argument owners to edit their statement text

### DIFF
--- a/frontend/src/components/EditQuestionModal.jsx
+++ b/frontend/src/components/EditQuestionModal.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import styles from './EditQuestionModal.module.css';
 
-export default function EditQuestionModal({ question, onSave, onCancel, isLoading }) {
+export default function EditQuestionModal({ question, onSave, onCancel, isLoading, title, maxLength = 1000 }) {
     const { t } = useTranslation();
     const [value, setValue] = useState(question);
     const inputRef = useRef(null);
@@ -29,8 +29,8 @@ export default function EditQuestionModal({ question, onSave, onCancel, isLoadin
 
     return (
         <div className={styles.overlay} onClick={onCancel}>
-            <div className={styles.modal} onClick={(e) => e.stopPropagation()} role="dialog" aria-label={t('decision.editQuestion')}>
-                <h2 className={styles.title}>{t('decision.editQuestion')}</h2>
+            <div className={styles.modal} onClick={(e) => e.stopPropagation()} role="dialog" aria-label={title || t('decision.editQuestion')}>
+                <h2 className={styles.title}>{title || t('decision.editQuestion')}</h2>
                 <form onSubmit={handleSubmit}>
                     <input
                         ref={inputRef}
@@ -38,7 +38,7 @@ export default function EditQuestionModal({ question, onSave, onCancel, isLoadin
                         type="text"
                         value={value}
                         onChange={(e) => setValue(e.target.value)}
-                        maxLength={1000}
+                        maxLength={maxLength}
                         disabled={isLoading}
                     />
                     <div className={styles.actions}>

--- a/frontend/src/components/StatementCard.jsx
+++ b/frontend/src/components/StatementCard.jsx
@@ -1,8 +1,10 @@
 import React, { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { voteArgument, subscribeToArgumentVotes } from '../services/firebase';
+import { voteArgument, updateArgumentText, subscribeToArgumentVotes } from '../services/firebase';
 import { useUser } from '../contexts/UserContext';
 import ParticipantService from '../services/ParticipantService';
+import EncryptionService from '../services/EncryptionService';
+import EditQuestionModal from './EditQuestionModal';
 import styles from './StatementCard.module.css';
 
 function HeartFilledIcon() {
@@ -21,11 +23,21 @@ function HeartOutlineIcon() {
     );
 }
 
+function PencilIcon() {
+    return (
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
+            <path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.39-.39-1.02-.39-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z" />
+        </svg>
+    );
+}
+
 export default function StatementCard({ argument, decisionId, readOnly, canVote, participantMap, encryptionKey, onVoteChange, onNameRequired, onError }) {
     const { t } = useTranslation();
     const { user } = useUser();
     const [votes, setVotes] = useState([]);
     const [voting, setVoting] = useState(false);
+    const [showEditModal, setShowEditModal] = useState(false);
+    const [editLoading, setEditLoading] = useState(false);
 
     useEffect(() => {
         const unsubscribe = subscribeToArgumentVotes(decisionId, argument.id, (newVotes) => {
@@ -71,6 +83,23 @@ export default function StatementCard({ argument, decisionId, readOnly, canVote,
         }
     };
 
+    const handleEditSave = async (newText) => {
+        setEditLoading(true);
+        try {
+            let textToSend = newText;
+            if (encryptionKey) {
+                textToSend = await EncryptionService.encrypt(newText, encryptionKey);
+            }
+            await updateArgumentText(decisionId, argument.id, textToSend);
+            setShowEditModal(false);
+        } catch (error) {
+            console.error("Error editing argument:", error);
+            if (onError) onError(t('argumentItem.errorEditFailed'));
+        } finally {
+            setEditLoading(false);
+        }
+    };
+
     const authorName = participantMap?.get(argument.authorId)?.name || argument.authorName;
 
     return (
@@ -82,7 +111,28 @@ export default function StatementCard({ argument, decisionId, readOnly, canVote,
                         : t('argumentItem.statementBy', { name: authorName || t('decision.anonymous') })
                     }
                 </span>
+                {isOwn && !readOnly && (
+                    <button
+                        className={styles.editButton}
+                        onClick={() => setShowEditModal(true)}
+                        aria-label={t('argumentItem.editButton')}
+                        type="button"
+                    >
+                        <PencilIcon />
+                    </button>
+                )}
             </div>
+
+            {showEditModal && (
+                <EditQuestionModal
+                    question={argument.text}
+                    title={t('argumentItem.editArgument')}
+                    maxLength={2000}
+                    onSave={handleEditSave}
+                    onCancel={() => setShowEditModal(false)}
+                    isLoading={editLoading}
+                />
+            )}
 
             <div className={styles.body}>
                 <span className={styles.text}>{argument.text}</span>

--- a/frontend/src/components/StatementCard.module.css
+++ b/frontend/src/components/StatementCard.module.css
@@ -30,6 +30,23 @@
   font-weight: 600;
 }
 
+.editButton {
+  background: transparent;
+  border: none;
+  color: var(--color-text-muted-alt);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  padding: 0;
+  transition: color 0.2s;
+}
+
+.editButton:hover {
+  color: var(--color-accent-secondary);
+}
+
 .body {
   display: flex;
   align-items: flex-start;

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -406,7 +406,10 @@
     "yourStatement": "Dein Statement",
     "approvalFrom": "Zustimmung von",
     "addedBy": "Hinzugefügt von {{name}}",
-    "errorVoteFailed": "Abstimmung fehlgeschlagen. Bitte versuche es erneut."
+    "errorVoteFailed": "Abstimmung fehlgeschlagen. Bitte versuche es erneut.",
+    "editButton": "Statement bearbeiten",
+    "editArgument": "Statement bearbeiten",
+    "errorEditFailed": "Änderungen konnten nicht gespeichert werden. Bitte versuche es erneut."
   },
   "argumentList": {
     "titlePros": "Pro",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -406,7 +406,10 @@
     "yourStatement": "Your Statement",
     "approvalFrom": "Approval from",
     "addedBy": "Added by {{name}}",
-    "errorVoteFailed": "Failed to vote. Please try again."
+    "errorVoteFailed": "Failed to vote. Please try again.",
+    "editButton": "Edit statement",
+    "editArgument": "Edit Statement",
+    "errorEditFailed": "Failed to save changes. Please try again."
   },
   "argumentList": {
     "titlePros": "Pros",

--- a/frontend/src/services/firebase.js
+++ b/frontend/src/services/firebase.js
@@ -110,6 +110,11 @@ export const addArgument = async (decisionId, type, text, authorName, authorId) 
     return result.data.id;
 };
 
+export const updateArgumentText = async (decisionId, argumentId, text) => {
+    const updateFn = httpsCallable(functions, 'updateArgumentText');
+    return await updateFn({ decisionId, argumentId, text });
+};
+
 export const voteArgument = async (decisionId, argumentId, displayName) => {
     const voteArgumentFunction = httpsCallable(functions, 'voteArgument');
     return await voteArgumentFunction({ decisionId, argumentId, displayName });

--- a/functions/index.js
+++ b/functions/index.js
@@ -121,6 +121,57 @@ exports.addArgument = onCall({cors: true, enforceAppCheck: enforceAppCheck}, asy
 });
 
 /**
+ * Updates the text of an existing argument. Author-only.
+ * @param {Object} request - The request object.
+ * @param {string} request.data.decisionId - The ID of the decision.
+ * @param {string} request.data.argumentId - The ID of the argument.
+ * @param {string} request.data.text - The new argument text.
+ * @return {Promise<Object>} Success status.
+ */
+exports.updateArgumentText = onCall({cors: true, enforceAppCheck: enforceAppCheck}, async (request) => {
+  if (!request.auth) {
+    throw new HttpsError("unauthenticated", "The function must be called while authenticated.");
+  }
+
+  const {decisionId, argumentId, text} = request.data;
+  const userId = request.auth.uid;
+
+  if (!decisionId || !argumentId || !text || typeof text !== "string" || text.trim().length === 0) {
+    throw new HttpsError("invalid-argument", "Missing or invalid decisionId, argumentId, or text.");
+  }
+
+  if (text.length > 2000) {
+    throw new HttpsError("invalid-argument", "Text must be under 2000 characters.");
+  }
+
+  const decisionRef = db.collection("decisions").doc(decisionId);
+  const decisionDoc = await decisionRef.get();
+
+  if (!decisionDoc.exists) {
+    throw new HttpsError("not-found", "Decision not found.");
+  }
+
+  if (decisionDoc.data().status === "closed") {
+    throw new HttpsError("failed-precondition", "Decision is closed.");
+  }
+
+  const argumentRef = decisionRef.collection("arguments").doc(argumentId);
+  const argumentDoc = await argumentRef.get();
+
+  if (!argumentDoc.exists) {
+    throw new HttpsError("not-found", "Argument not found.");
+  }
+
+  if (argumentDoc.data().authorId !== userId) {
+    throw new HttpsError("permission-denied", "Only the author can edit this argument.");
+  }
+
+  await argumentRef.update({text: text.trim()});
+
+  return {success: true};
+});
+
+/**
  * Votes on an argument.
  * @param {Object} request - The request object.
  * @param {string} request.data.decisionId - The ID of the decision.


### PR DESCRIPTION
## Summary
- New `updateArgumentText` Cloud Function (`functions/index.js`), mirroring `updateDecisionQuestion`'s pattern: requires auth, validates length (1–2000 chars, matching `addArgument`'s limit), blocks edits on closed decisions (matching `voteArgument`'s existing check), and authorizes on `argument.authorId === request.auth.uid` (not the decision owner — anyone can own an argument they authored).
- `StatementCard.jsx` gets a small pencil-icon edit trigger next to the author label, shown only when `isOwn && !readOnly`.
- Reused `EditQuestionModal` for the edit UI rather than duplicating it — generalized it with optional `title`/`maxLength` props (defaults preserve the existing question-edit behavior unchanged).
- Handles E2E encryption: if the decision has an `encryptionKey`, the new text is encrypted client-side before being sent, same as `handleEditSave` already does for the decision question in `Decision.jsx`.
- Added `argumentItem.editButton` / `argumentItem.editArgument` / `argumentItem.errorEditFailed` i18n keys (en + de).

Fixes #196

## Test plan
- [x] `npm run lint` passes (frontend + functions)
- [x] Full frontend test suite passes (149/149)
- [x] Locale JSON files parse correctly
- [ ] Manual: as an argument's author, edit its text and confirm it updates for all participants; confirm the edit icon does NOT show on other users' statements or when the decision is closed